### PR TITLE
fix: Traded Pokemon shiny in-game issue

### DIFF
--- a/include/Pokemon/Pokemon8SWSH.h
+++ b/include/Pokemon/Pokemon8SWSH.h
@@ -168,7 +168,7 @@ namespace Pokemon {
          * the original nature. This value determines which nature affects stats.
          * @return Stat Nature ID (0-24)
          */
-        uint8_t statNature() const noexcept
+        uint8_t statNature() const noexcept override
         {
             return static_cast<uint8_t>(data[0x21]);
         }

--- a/include/Pokemon/Pokemon9LZA.h
+++ b/include/Pokemon/Pokemon9LZA.h
@@ -173,7 +173,7 @@ namespace Pokemon {
          * the original nature. This value determines which nature affects stats.
          * @return Stat Nature ID (0-24)
          */
-        uint8_t statNature() const noexcept
+        uint8_t statNature() const noexcept override
         {
             return static_cast<uint8_t>(data[0x21]);
         }

--- a/src/UI/Modals/PokemonDetailsModal.cpp
+++ b/src/UI/Modals/PokemonDetailsModal.cpp
@@ -139,7 +139,8 @@ namespace Modals {
             if (screen.pokemonDetailsEditing && screen.pokemonDetailsSelectedField == 3) {
                 fb.drawText(contentX - 15, lineY, ">", Colors::Yellow);
             }
-            snprintf(buffer, sizeof(buffer), "Shiny: %s", pokemon->isShiny(screen.trainer.ID32, pokemon->species()) ? "Yes" : "No");
+            // snprintf(buffer, sizeof(buffer), "Shiny: %s", pokemon->isShiny(screen.trainer.ID32, pokemon->species()) ? "Yes" : "No");
+            snprintf(buffer, sizeof(buffer), "Shiny: %s", pokemon->isShiny(pokemon->id32(), pokemon->species()) ? "Yes" : "No");
             Color shinyColor = screen.pokemonDetailsEditing && screen.pokemonDetailsSelectedField == 3 ? Colors::Yellow : Colors::Text;
             fb.drawText(contentX, lineY, buffer, shinyColor);
             if (screen.pokemonDetailsEditing && screen.pokemonDetailsSelectedField == 3) {

--- a/src/UI/Panels/BoxPokemonPanel.cpp
+++ b/src/UI/Panels/BoxPokemonPanel.cpp
@@ -74,11 +74,12 @@ namespace Panels {
                         continue;
                     }
 
-                    // Load and draw Pokemon sprite icon (left side of cell, smaller)
-                    bool isShiny = pokemon->isShiny(screen.trainer.ID32, speciesName);
+                    // Load and draw Pokemon sprite icon
+                    // bool isShiny = pokemon->isShiny(screen.trainer.ID32, speciesName);
+                    bool isShiny = pokemon->isShiny(pokemon->id32(), speciesName);
                     Sprite* sprite = SpriteManager::getIconSprite(pokemon->speciesID(), isShiny);
 
-                    const int SPRITE_SIZE = 50;  // Scaled down sprite size (was 96x96, now 50x50)
+                    const int SPRITE_SIZE = 50;  // Scaled down sprite size to 50x50
                     int spriteWidth = 0;
                     if (sprite && sprite->data) {
                         // Position sprite on left side of cell, centered vertically
@@ -107,7 +108,7 @@ namespace Panels {
                     }
 
                     // Add shiny star in red after gender
-                    if (pokemon->isShiny(screen.trainer.ID32, speciesName)) {
+                    if (pokemon->isShiny(pokemon->id32(), speciesName)) {
                         fb.drawText(textX, slotY + 10, " ★", Colors::Red);
                     }
 
@@ -117,11 +118,6 @@ namespace Panels {
                         snprintf(levelText, sizeof(levelText), "Lv.%d", pokemon->level());
                         fb.drawText(slotX + 5 + spriteWidth, slotY + 30, levelText, Colors::TextDim);
                     }
-
-                    // // Show cursor if this slot is selected in detail view
-                    // if (screen.detailViewActive && slotIndex == screen.selectedItemIndex) {
-                    //     fb.drawText(slotX + 5, slotY + 60, "> Selected", Colors::Yellow);
-                    // }
                 } else {
                     // Empty slot
                     fb.drawText(slotX + 5, slotY + 35, "Empty", Colors::TextDim);

--- a/src/UI/Panels/PartyPokemonPanel.cpp
+++ b/src/UI/Panels/PartyPokemonPanel.cpp
@@ -47,7 +47,8 @@ namespace Panels {
             }
 
             // Load and draw Pokemon sprite to the right of stats
-            bool isShiny = pokemon->isShiny(trainerID32, pokemon->species());
+            // bool isShiny = pokemon->isShiny(trainerID32, pokemon->species());
+            bool isShiny = pokemon->isShiny(pokemon->id32(), pokemon->species());
             Sprite* sprite = SpriteManager::getSprite(pokemon->speciesID(), isShiny);
 
             if (sprite && sprite->data) {
@@ -74,7 +75,8 @@ namespace Panels {
             }
 
             // Draw shiny star in red after gender
-            if (pokemon->isShiny(trainerID32, pokemon->species())) {
+            // if (pokemon->isShiny(trainerID32, pokemon->species())) {
+            if (pokemon->isShiny(pokemon->id32(), pokemon->species())) {
                 fb.drawText(textX, colY, " ★", Colors::Red);
                 textX += 16;
             }

--- a/src/UI/TrainerViewScreen.cpp
+++ b/src/UI/TrainerViewScreen.cpp
@@ -240,7 +240,8 @@ namespace UI {
 
                         // Regenerate PID to maintain legality after IV/EV changes
                         if (statsModified) {
-                            pokemon->regeneratePID(trainer.ID32);
+                            // pokemon->regeneratePID(trainer.ID32);
+                            pokemon->regeneratePID(pokemon->id32());
                         }
 
                         statEditDialogActive = false;
@@ -328,8 +329,10 @@ namespace UI {
                         if (pokemonDetailsSelectedField == 3) {
                             // Toggle shiny status
                             logInfoToFile("Shiny field selected, toggling...");
-                            bool currentShiny = pokemon->isShiny(trainer.ID32, pokemon->species());
-                            pokemon->setShiny(!currentShiny, trainer.ID32);
+                            // bool currentShiny = pokemon->isShiny(trainer.ID32, pokemon->species());
+                            // pokemon->setShiny(!currentShiny, trainer.ID32);
+                            bool currentShiny = pokemon->isShiny(pokemon->id32(), pokemon->species());
+                            pokemon->setShiny(!currentShiny, pokemon->id32());
                             hasUnsavedChanges = true;
                         }
                         // Future: Handle other fields (PID, Species, Gender, Nickname, EXP, Level, Nature, Held Item, Ability)


### PR DESCRIPTION
Fixed a bug that caused traded Pokemon to not show as shiny in-game for both SWSH and Legends: Z-A. (#36)