### PR TITLE
fix: Gen 9 species-index decode + SWSH/SV/ZA trainer-info read bugs

### DIFF
--- a/include/Pokemon/Pokemon9LZA.h
+++ b/include/Pokemon/Pokemon9LZA.h
@@ -28,6 +28,7 @@
 #include <string>
 
 #include "Pokemon/Pokemon.h"
+#include "Pokemon/SpeciesConverter9.h"
 #include "Encryption/Encryption9LZA.h"
 #include "Utils/HelperUtilities.h"
 #include "Utils/StringHelpers.h"
@@ -96,7 +97,10 @@ namespace Pokemon {
          */
         uint16_t speciesID() const noexcept override
         {
-            return readUInt16LittleEndian(reinterpret_cast<const uint8_t*>(data.data() + 0x08));
+            // Z-A stores the same Gen 9 INTERNAL species index as S/V (PKHeX PA9 uses the identical
+            // SpeciesConverter.GetNational9) -- convert on read; see Pokemon9SV.h / SpeciesConverter9.h.
+            return gen9InternalToNational(
+                readUInt16LittleEndian(reinterpret_cast<const uint8_t*>(data.data() + 0x08)));
         }
 
         /**
@@ -499,7 +503,9 @@ namespace Pokemon {
         /** Sets species (0x08) and recalculates stats (base stats change). */
         void setSpecies(uint16_t species) noexcept override
         {
-            writeUInt16LittleEndian(reinterpret_cast<uint8_t*>(data.data() + 0x08), species);
+            // Store the INTERNAL index (inverse of speciesID's read conversion; PKHeX PA9.GetInternal9).
+            writeUInt16LittleEndian(reinterpret_cast<uint8_t*>(data.data() + 0x08),
+                                    gen9NationalToInternal(species));
             recalculateStats();
             refreshChecksum();
         }

--- a/include/Pokemon/Pokemon9SV.h
+++ b/include/Pokemon/Pokemon9SV.h
@@ -28,6 +28,7 @@
 #include <string>
 
 #include "Pokemon/Pokemon.h"
+#include "Pokemon/SpeciesConverter9.h"
 #include "Encryption/Encryption9SV.h"
 #include "Utils/HelperUtilities.h"
 #include "Utils/StringHelpers.h"
@@ -96,7 +97,12 @@ namespace Pokemon {
          */
         uint16_t speciesID() const noexcept override
         {
-            return readUInt16LittleEndian(reinterpret_cast<const uint8_t*>(data.data() + 0x08));
+            // The raw u16 is the game's INTERNAL species index, which diverges from the National Dex
+            // from #917 on -- convert like PKHeX PK9 (SpeciesConverter.GetNational9), the same way FRLG
+            // already converts Gen 3's internal order (g3ToNational). Reading it raw showed the wrong
+            // species (name/sprite/type/legality) for every newer Paldea Pokemon.
+            return gen9InternalToNational(
+                readUInt16LittleEndian(reinterpret_cast<const uint8_t*>(data.data() + 0x08)));
         }
 
         /**
@@ -495,7 +501,10 @@ namespace Pokemon {
         /** Sets species (0x08) and recalculates stats (base stats change). */
         void setSpecies(uint16_t species) noexcept override
         {
-            writeUInt16LittleEndian(reinterpret_cast<uint8_t*>(data.data() + 0x08), species);
+            // Store the INTERNAL index (inverse of speciesID's read conversion) -- the game reads this
+            // field, so writing the National Dex number raw makes it show a different species.
+            writeUInt16LittleEndian(reinterpret_cast<uint8_t*>(data.data() + 0x08),
+                                    gen9NationalToInternal(species));
             recalculateStats();
             refreshChecksum();
         }

--- a/include/Pokemon/SpeciesConverter9.h
+++ b/include/Pokemon/SpeciesConverter9.h
@@ -1,0 +1,89 @@
+/**
+ * SpeciesConverter9.h - Gen 9 internal <-> National Dex species index conversion.
+ *
+ * Scarlet/Violet and Legends: Z-A do NOT store the National Dex number in an entity's
+ * species field (u16 @ 0x08). From #917 (Tarountula) onward the games' INTERNAL species
+ * order diverges from the final National Dex assignment, so the stored value must be
+ * converted on every read and write -- exactly like Gen 3 (see g3ToNational /
+ * nationalToG3 in Pokemon3FRLG.h, the same concept for FR/LG's internal order).
+ *
+ * PKHeX reference (source of truth):
+ *   - PK9.cs / PA9.cs: `Species => SpeciesConverter.GetNational9(SpeciesInternal)`
+ *   - PKHeX.Core/PKM/Util/Conversion/SpeciesConverter.cs:
+ *       FirstUnalignedNational9 = 917; Table9NationalToInternal / Table9InternalToNational
+ *
+ * Reading the raw value as a dex number displayed the WRONG species (wrong name, sprite,
+ * types, base stats, learnset -> false legality errors) for every mon whose stored id is
+ * >= 917. Both tables are delta tables: result = input + table[input - 917]; identity for
+ * anything outside the table (species < 917, and future ids past the table's end).
+ * Do not hand-edit the deltas -- they are copied verbatim from PKHeX.
+ */
+
+#ifndef POKEMON_SPECIES_CONVERTER9_H
+#define POKEMON_SPECIES_CONVERTER9_H
+
+#include <cstdint>
+
+namespace Pokemon {
+
+    /// First species id where the Gen 9 internal order and the National Dex diverge.
+    inline constexpr uint16_t GEN9_FIRST_UNALIGNED_SPECIES = 917;
+
+    /// Deltas indexed by (national - 917): internal = national + delta. PKHeX Table9NationalToInternal.
+    inline constexpr int8_t GEN9_NATIONAL_TO_INTERNAL[109] = {
+                                  1,   1,   1,
+          1,  33,  33,  33,  21,  21,  44,  44,   7,   7,
+          7,  29,  31,  31,  31,  68,  68,  68,   2,   2,
+         17,  17,  30,  30,  24,  24,  28,  28,  58,  58,
+         12, -13, -13, -31, -31, -29, -29,  43,  43,  43,
+        -31, -31,  -3, -30, -30, -23, -23, -14, -24,  -3,
+         -3, -47, -47, -12, -27, -27, -44, -46, -26,  31,
+         29, -53, -65,  25,  -6,  -3,  -7,  -4,  -4,  -8,
+         -4,   1,  -3,  -3,  -6,  -4, -47, -47, -47, -23,
+        -23,  -5,  -7,  -9,  -7, -20, -13,  -9,  -9, -29,
+        -23,   1,  12,  12,   0,   0,   0,  -6,   5,  -6,
+         -3,  -3,  -2,  -4,  -3,  -3,
+    };
+
+    /// Deltas indexed by (internal - 917): national = internal + delta. PKHeX Table9InternalToNational.
+    inline constexpr int8_t GEN9_INTERNAL_TO_NATIONAL[109] = {
+                                 65,  -1,  -1,
+         -1,  -1,  31,  31,  47,  47,  29,  29,  53,  31,
+         31,  46,  44,  30,  30,  -7,  -7,  -7,  13,  13,
+         -2,  -2,  23,  23,  24, -21, -21,  27,  27,  47,
+         47,  47,  26,  14, -33, -33, -33, -17, -17,   3,
+        -29,  12, -12, -31, -31, -31,   3,   3, -24, -24,
+        -44, -44, -30, -30, -28, -28,  23,  23,   6,   7,
+         29,   8,   3,   4,   4,  20,   4,  23,   6,   3,
+          3,   4,  -1,  13,   9,   7,   5,   7,   9,   9,
+        -43, -43, -43, -68, -68, -68, -58, -58, -25, -29,
+        -31,   6,  -1,   6,   0,   0,   0,   3,   3,   4,
+          2,   3,   3,  -5, -12, -12,
+    };
+
+    /// Raw stored species (SV / Z-A internal index) -> National Dex number. Identity outside the table.
+    inline constexpr uint16_t gen9InternalToNational(uint16_t raw) noexcept {
+        const uint32_t shift = static_cast<uint32_t>(raw) - GEN9_FIRST_UNALIGNED_SPECIES;
+        if (shift >= sizeof(GEN9_INTERNAL_TO_NATIONAL)) return raw;   // < 917 wraps huge -> identity
+        return static_cast<uint16_t>(raw + GEN9_INTERNAL_TO_NATIONAL[shift]);
+    }
+
+    /// National Dex number -> raw stored species (SV / Z-A internal index). Identity outside the table.
+    inline constexpr uint16_t gen9NationalToInternal(uint16_t national) noexcept {
+        const uint32_t shift = static_cast<uint32_t>(national) - GEN9_FIRST_UNALIGNED_SPECIES;
+        if (shift >= sizeof(GEN9_NATIONAL_TO_INTERNAL)) return national;
+        return static_cast<uint16_t>(national + GEN9_NATIONAL_TO_INTERNAL[shift]);
+    }
+
+    // Compile-time spot checks from the field report that exposed this (all PKHeX-verified):
+    // stored 967 must read Glimmora (970), 1003 -> Charcadet (935), 917 -> Dudunsparce (982).
+    static_assert(gen9InternalToNational(967) == 970,  "Gen9 species table: 967 -> Glimmora");
+    static_assert(gen9InternalToNational(1003) == 935, "Gen9 species table: 1003 -> Charcadet");
+    static_assert(gen9InternalToNational(917) == 982,  "Gen9 species table: 917 -> Dudunsparce");
+    static_assert(gen9NationalToInternal(970) == 967,  "Gen9 species table: Glimmora -> 967");
+    static_assert(gen9NationalToInternal(935) == 1003, "Gen9 species table: Charcadet -> 1003");
+    static_assert(gen9NationalToInternal(916) == 916,  "Gen9 species table: aligned below 917");
+    static_assert(gen9InternalToNational(0) == 0,      "Gen9 species table: empty slot is identity");
+}
+
+#endif

--- a/src/Conversion/Convert.cpp
+++ b/src/Conversion/Convert.cpp
@@ -13,6 +13,7 @@
 #include "Pokemon/Pokemon9SV.h"
 #include "Pokemon/Pokemon9LZA.h"
 #include "Pokemon/Pokemon3FRLG.h"        // PK3 entity + g3ToNational / nationalToG3
+#include "Pokemon/SpeciesConverter9.h"   // gen9InternalToNational / gen9NationalToInternal (PK9/PA9 species field)
 #include "Pokemon/BaseStatsGen89.h"      // getSpeciesNameGen89 (Gen 3 nickname = uppercase species name)
 #include "Pokemon/PersonalInfoTable.h"
 #include "Pokemon/PokemonTypes.h"       // getPokemonTypes -> Tera type for cross-gen PK8->PK9
@@ -228,6 +229,9 @@ namespace Conversion {
         // PK8 -> PK9, in place. `species`/`form` are the source's (for the imported Tera type).
         void transformG8toG9(std::vector<std::byte>& b, uint16_t species, uint8_t form) {
             if (b.size() < 0x148) return;
+            // 0x08 species: the PK8 hub stores the NATIONAL dex number, but PK9/PA9 store the Gen 9
+            // INTERNAL index (diverges from #917 on) -- convert, or the game shows a shifted species.
+            wr16(b, 0x08, Pokemon::gen9NationalToInternal(rd16(b, 0x08)));
             // 0x16 bit4 CanGigantamax -> PK9 has no G-Max: clear it.
             wr8(b, 0x16, rd8(b, 0x16) & ~0x10);
             // 0x22 gender: PK8 (byte>>2)&3 -> PK9 (byte>>1)&3. Keep Fateful(bit0); drop PK8 Flag2(bit1).
@@ -264,6 +268,9 @@ namespace Conversion {
         // PK9 -> PK8, in place (the mirror of transformG8toG9). Tera / ObedienceLevel / records are dropped.
         void transformG9toG8(std::vector<std::byte>& b) {
             if (b.size() < 0x148) return;
+            // 0x08 species: PK9/PA9 store the Gen 9 INTERNAL index; the PK8 hub (and every format fed
+            // from it) uses the NATIONAL dex number -- convert (mirror of transformG8toG9).
+            wr16(b, 0x08, Pokemon::gen9InternalToNational(rd16(b, 0x08)));
             // 0x22 gender: PK9 (byte>>1)&3 -> PK8 (byte>>2)&3. Keep Fateful(bit0); PK8 Flag2(bit1) stays 0.
             { uint8_t v = rd8(b, 0x22); uint8_t fateful = v & 0x01; uint8_t gender = (v >> 1) & 0x03;
               wr8(b, 0x22, fateful | (gender << 2)); }

--- a/src/Trainer/Trainer8SWSH.cpp
+++ b/src/Trainer/Trainer8SWSH.cpp
@@ -75,6 +75,15 @@ namespace Trainer {
         this->SID16 = readUInt16LittleEndian(&block.data[0xA2]);
         this->TID = this->ID32 % 1000000;
         this->SID = this->ID32 / 1000000;
+
+        // OT name (0xB0, 26 bytes) and gender (0xA5) come from MyStatus8 -- the authoritative source
+        // PKHeX uses (SAV8SWSH.OT/Gender => MyStatus, alongside ID32 at 0xA0). They were previously read
+        // from the Trainer Card block (a display copy), whose byte at 0xA5 is NOT the gender field, so the
+        // trainer gender shown could be a wrong/garbage value.
+        if (block.data.size() >= 0xB0 + 0x1A)
+            this->trainerName = utf16ToUtf8(getString(&block.data[0xB0], 0x1A));
+        if (block.data.size() > 0xA5)
+            this->trainerGender = block.data[0xA5] & 1;   // 0xA5: gender (0=M, 1=F)
     }
 
     void Trainer8SWSH::parsePartyBlock(const Block& block)
@@ -142,10 +151,9 @@ namespace Trainer {
          * 0x00: Trainer Name (26 bytes, UTF-16LE)
          * 0x1C: Trainer ID (4 bytes) - Legacy trainer ID format
          */
-        // Parse trainer name (UTF-16LE string)
-        size_t nameLength = std::min(static_cast<size_t>(0x1A), block.data.size());
-        this->trainerName = utf16ToUtf8(getString(block.data.data(), nameLength));
-        if (block.data.size() > 0xA5) this->trainerGender = block.data[0xA5] & 1;   // 0xA5: gender
+        // OT name and gender are read from MyStatus8 (the authoritative block), not from this display
+        // copy -- see parseMyStatusBlock. Nothing else in the Trainer Card is consumed yet.
+        (void)block;
     }
 
     void Trainer8SWSH::parseItemBlock(const Block& block)

--- a/src/Trainer/Trainer9LZA.cpp
+++ b/src/Trainer/Trainer9LZA.cpp
@@ -74,9 +74,11 @@ namespace Trainer {
         this->SID16 = readUInt16LittleEndian(&block.data[0x02]);
         this->TID = this->ID32 % 1000000;
         this->SID = this->ID32 / 1000000;
-        size_t nameLength = std::min(static_cast<size_t>(0x10), static_cast<size_t>(0x1A));
-        auto nameSpan = std::span<const uint8_t>(block.data.data() + 0x10, nameLength);
-        this->trainerName = utf16ToUtf8(getString(nameSpan.data(), nameLength));
+        // OT name is a 26-byte (0x1A) field at 0x10 -- PKHeX MyStatus9.OriginalTrainerTrash =
+        // Data.Slice(0x10, 0x1A). The old min(0x10, 0x1A) mistakenly used the OFFSET (0x10 = 16 bytes =
+        // 8 code units) as the length, truncating any trainer name longer than 8 characters.
+        if (block.data.size() >= 0x10 + 0x1A)
+            this->trainerName = utf16ToUtf8(getString(&block.data[0x10], 0x1A));
         this->trainerGender = block.data[0x05] & 1;   // 0x05: gender (0=M, 1=F)
         logInfoToFile("Parsed Trainer Name", this->trainerName.c_str());
     }

--- a/src/Trainer/Trainer9SV.cpp
+++ b/src/Trainer/Trainer9SV.cpp
@@ -74,9 +74,11 @@ namespace Trainer {
         this->SID16 = readUInt16LittleEndian(&block.data[0x02]);
         this->TID = this->ID32 % 1000000;
         this->SID = this->ID32 / 1000000;
-        size_t nameLength = std::min(static_cast<size_t>(0x10), static_cast<size_t>(0x1A));
-        auto nameSpan = std::span<const uint8_t>(block.data.data() + 0x10, nameLength);
-        this->trainerName = utf16ToUtf8(getString(nameSpan.data(), nameLength));
+        // OT name is a 26-byte (0x1A) field at 0x10 -- PKHeX MyStatus9.OriginalTrainerTrash =
+        // Data.Slice(0x10, 0x1A). The old min(0x10, 0x1A) mistakenly used the OFFSET (0x10 = 16 bytes =
+        // 8 code units) as the length, truncating any trainer name longer than 8 characters.
+        if (block.data.size() >= 0x10 + 0x1A)
+            this->trainerName = utf16ToUtf8(getString(&block.data[0x10], 0x1A));
         this->trainerGender = block.data[0x05] & 1;   // 0x05: gender (0=M, 1=F)
         logInfoToFile("Parsed Trainer Name", this->trainerName.c_str());
     }


### PR DESCRIPTION
Three read-path fixes for the v1.0.1 hotfix. Verified against a real Pokemon Violet 4.0.0 save.

- SV / Z-A species: PK9 and PA9 store an INTERNAL species index that diverges from the National Dex from #917 (Tarountula) onward. Reading it raw showed the WRONG species for every newer Paldea Pokemon -- wrong name, dex number, sprite, type, base stats, learnset and legality (e.g. a Glimmora displayed as Cyclizar, flagging false legality errors). Port PKHeX's SpeciesConverter (both delta tables, FirstUnalignedNational9=917) and convert on every species read/write and in the PK8-hub cross-gen transforms. Mirrors the existing Gen 3 g3ToNational handling. New include/Pokemon/SpeciesConverter9.h; Pokemon9SV.h, Pokemon9LZA.h, Convert.cpp. Closes #58

- Sword/Shield trainer name + gender: read from the authoritative MyStatus8 block (name @0xB0, gender @0xA5) instead of the Trainer Card display copy. The Trainer Card byte at 0xA5 is not the gender field, so the displayed trainer gender could be wrong. Trainer8SWSH.cpp. Closes #56

- Scarlet/Violet + Z-A trainer name: read the full 26-byte (0x1A) OT name field. The old min(0x10, 0x1A) used the field OFFSET as the length and truncated any trainer name longer than 8 characters. Trainer9SV.cpp, Trainer9LZA.cpp. Closes #57