### PR TITLE
fix: 3 critical bugs were found and fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ APP_AUTHOR  :=  Kiasta
 # single source of truth -- the two can no longer drift.
 # NOTE: no trailing comment on the assignment line. Make keeps trailing whitespace in a value, so
 # "0.0.3 \t\t# ..." would have baked spaces into the .nacp version and the -D define.
-APP_VERSION :=	1.0.2
+APP_VERSION :=	1.0.3
 ROMFS		:=	romfs
 ICON		:=  icon.jpg
 

--- a/include/UI/PKSEFramebuffer.h
+++ b/include/UI/PKSEFramebuffer.h
@@ -41,6 +41,13 @@ namespace UI {
         void drawImageScaled(int x, int y, int imgWidth, int imgHeight, int destWidth, int destHeight, const unsigned char* imageData, int channels);
         void flush();
 
+        // Textures are cached under the ADDRESS of the pixel buffer they were built from, so when
+        // the sprite cache frees a buffer its texture has to go too -- otherwise a later sprite
+        // allocated at that same address would be drawn with the freed one's image. Hooked up to
+        // SpriteManager's eviction callback; onSpriteEvicted forwards to the live framebuffer.
+        void invalidateImage(const unsigned char* data);
+        static void onSpriteEvicted(const unsigned char* data);
+
         // Clip subsequent drawing to a rectangle (for a scrollable region); clearClip() removes it.
         // Both need an active frame; primitives outside the clip rect are not rendered.
         void setClipRect(int x, int y, int w, int h);

--- a/include/UI/SpriteManager.h
+++ b/include/UI/SpriteManager.h
@@ -1,7 +1,9 @@
 #ifndef UI_SPRITE_MANAGER_H
 #define UI_SPRITE_MANAGER_H
 
+#include <cstddef>
 #include <cstdint>
+#include <list>
 #include <map>
 #include <string>
 
@@ -47,12 +49,37 @@ namespace UI {
 
         static bool typeSpriteExists(uint8_t typeId);
 
+        // Called just before a sprite's pixel buffer is freed. The renderer caches the texture it
+        // built from that buffer under the buffer's ADDRESS, so it has to drop it in step: a later
+        // sprite allocated at the same address would otherwise be drawn with the evicted one's
+        // image. Registered by the renderer; cleared when the renderer goes away.
+        using EvictFn = void (*)(const unsigned char* data);
+        static void setEvictCallback(EvictFn fn);
+
+        // Bytes of decoded pixel data currently held. Exposed for diagnostics/logging.
+        static size_t cachedBytes();
+
     private:
         // Load a sprite from ROMFS
         static Sprite* loadSprite(const std::string& path);
 
+        // Pokemon sprites are the only cache that grows with use -- one 256px HD sprite decodes to
+        // 256 KB, and a full save has hundreds -- so it is capped and evicts least-recently-used.
+        // The 18 type icons are naturally bounded and stay a simple map.
+        struct SpriteEntry {
+            Sprite* sprite;                      // may be null: a failed load is cached too
+            std::list<uint32_t>::iterator lru;   // position in spriteLru
+        };
+
         // Sprite cache: key = species ID | (isShiny << 16) | (isIcon << 17) | (form << 18)
-        static std::map<uint32_t, Sprite*> spriteCache;
+        static std::map<uint32_t, SpriteEntry> spriteCache;
+        static std::list<uint32_t> spriteLru;    // front = most recently used
+        static size_t spriteBytes;
+        static EvictFn evictCallback;
+
+        // Drop least-recently-used sprites until the cache is back inside its budget.
+        static void trimToBudget();
+        static void releaseSprite(Sprite* sprite);
 
         // Type sprite cache: key = type ID
         static std::map<uint8_t, Sprite*> typeSpriteCache;

--- a/include/UI/TrainerViewScreen.h
+++ b/include/UI/TrainerViewScreen.h
@@ -160,6 +160,10 @@ namespace UI {
         // Leaving the storage view with unsaved bank changes: prompt Save / Discard / Cancel (PKSM-style).
         bool storageExitConfirmActive = false;
         int storageExitConfirmIndex = 0;   // 0=Save & Exit, 1=Discard & Exit, 2=Cancel
+        // Set when + (exit app) raised that prompt instead of B. Closing the app is not an answer to
+        // "save the bank?", so + asks first and the exit resumes once Save or Discard has been picked.
+        bool exitAfterBankChoice = false;
+        void beginAppExit();   // the + handler's tail: prompt about the game save, else leave
         // Touchable storage slot rects, captured during draw for tap hit-testing next frame.
         struct TouchTarget { int pane, box, slot, x, y, w, h; };
         std::vector<TouchTarget> storageTouchTargets;

--- a/src/UI/PKSEFramebuffer.cpp
+++ b/src/UI/PKSEFramebuffer.cpp
@@ -12,6 +12,7 @@
 #define NANOVG_GL3
 #include "nanovg_gl.h"
 
+#include "UI/SpriteManager.h"   // eviction hook: textures are keyed on sprite buffer addresses
 #include "Utils/Logger.h"
 
 using namespace Utils;
@@ -31,6 +32,10 @@ namespace UI {
     };
 
     static inline NVGcolor toNVG(Color c) { return nvgRGBA(c.r, c.g, c.b, c.a); }
+
+    // The framebuffer SpriteManager's eviction callback should reach. Only one exists at a time
+    // (UIManager owns it), and it is cleared on destruction so a late eviction is a no-op.
+    static PKSEFramebuffer* s_activeFramebuffer = nullptr;
 
     // ---------------------------------------------------------------------------------------------
 
@@ -77,9 +82,27 @@ namespace UI {
         fontSym2 = nvgCreateFont(vg, "sym2", kSym2Path);
         if (fontSans >= 0 && fontSym  >= 0) nvgAddFallbackFontId(vg, fontSans, fontSym);
         if (fontSans >= 0 && fontSym2 >= 0) nvgAddFallbackFontId(vg, fontSans, fontSym2);
+
+        s_activeFramebuffer = this;
+        SpriteManager::setEvictCallback(&PKSEFramebuffer::onSpriteEvicted);
+    }
+
+    void PKSEFramebuffer::onSpriteEvicted(const unsigned char* data) {
+        if (s_activeFramebuffer) s_activeFramebuffer->invalidateImage(data);
+    }
+
+    void PKSEFramebuffer::invalidateImage(const unsigned char* data) {
+        if (!vg || !data) return;
+        auto it = imageCache.find(data);
+        if (it == imageCache.end()) return;
+        if (it->second >= 0) nvgDeleteImage(vg, it->second);
+        imageCache.erase(it);
     }
 
     PKSEFramebuffer::~PKSEFramebuffer() {
+        // Stop eviction reaching a half-destroyed object; the loop below frees every texture anyway.
+        SpriteManager::setEvictCallback(nullptr);
+        if (s_activeFramebuffer == this) s_activeFramebuffer = nullptr;
         if (vg) {
             for (auto& kv : imageCache) if (kv.second >= 0) nvgDeleteImage(vg, kv.second);
             imageCache.clear();

--- a/src/UI/SpriteManager.cpp
+++ b/src/UI/SpriteManager.cpp
@@ -11,10 +11,58 @@
 using namespace Utils;
 
 namespace UI {
+    namespace {
+        // Decoded pixel data the Pokemon sprite cache may hold. One 256px HD sprite is 256 KB, so
+        // this is roughly 190 of them -- several times the most that can be on screen at once (two
+        // 30-slot boxes, the party and a held mon), which is what matters: a budget under the
+        // working set would reload from ROMFS every frame instead of caching anything.
+        constexpr size_t SPRITE_CACHE_BUDGET = 48u * 1024u * 1024u;
+
+        size_t bytesOf(const Sprite* s) {
+            if (!s || !s->data) return 0;
+            return static_cast<size_t>(s->width) * static_cast<size_t>(s->height) *
+                   static_cast<size_t>(s->channels);
+        }
+    }
+
     // Static member initialization
-    std::map<uint32_t, Sprite*> SpriteManager::spriteCache;
+    std::map<uint32_t, SpriteManager::SpriteEntry> SpriteManager::spriteCache;
+    std::list<uint32_t> SpriteManager::spriteLru;
+    size_t SpriteManager::spriteBytes = 0;
+    SpriteManager::EvictFn SpriteManager::evictCallback = nullptr;
     std::map<uint8_t, Sprite*> SpriteManager::typeSpriteCache;
     bool SpriteManager::initialized = false;
+
+    void SpriteManager::setEvictCallback(EvictFn fn) { evictCallback = fn; }
+
+    size_t SpriteManager::cachedBytes() { return spriteBytes; }
+
+    // Frees a sprite's pixel buffer, telling the renderer first so the texture keyed on that
+    // buffer's address goes with it. Skipping that would leave a stale texture behind that a
+    // later sprite landing on the same address would silently be drawn with.
+    void SpriteManager::releaseSprite(Sprite* sprite) {
+        if (!sprite) return;
+        const size_t bytes = bytesOf(sprite);
+        if (bytes) {
+            spriteBytes = (spriteBytes >= bytes) ? spriteBytes - bytes : 0;
+            if (evictCallback) evictCallback(sprite->data);
+        }
+        delete sprite;
+    }
+
+    void SpriteManager::trimToBudget() {
+        // Never evict down to nothing: the entry just inserted is at the front, and the caller is
+        // about to return a pointer to it.
+        while (spriteBytes > SPRITE_CACHE_BUDGET && spriteLru.size() > 1) {
+            const uint32_t key = spriteLru.back();
+            spriteLru.pop_back();
+            auto it = spriteCache.find(key);
+            if (it != spriteCache.end()) {
+                releaseSprite(it->second.sprite);
+                spriteCache.erase(it);
+            }
+        }
+    }
 
     Sprite::~Sprite() {
         if (data) {
@@ -31,16 +79,16 @@ namespace UI {
     }
 
     void SpriteManager::cleanup() {
-        // Free all cached Pokemon sprites
-        for (auto& pair : spriteCache) {
-            delete pair.second;
-        }
-        spriteCache.clear();
+        // The renderer is torn down before this runs and takes every texture with it, so drop the
+        // callback rather than call into an object that is already gone.
+        evictCallback = nullptr;
 
-        // Free all cached type sprites
-        for (auto& pair : typeSpriteCache) {
-            delete pair.second;
-        }
+        for (auto& pair : spriteCache) delete pair.second.sprite;
+        spriteCache.clear();
+        spriteLru.clear();
+        spriteBytes = 0;
+
+        for (auto& pair : typeSpriteCache) delete pair.second;
         typeSpriteCache.clear();
 
         initialized = false;
@@ -78,10 +126,11 @@ namespace UI {
 
         uint32_t cacheKey = makeCacheKey(speciesId, formId, isShiny, false);
 
-        // Check cache first
+        // Check cache first; a hit is also the "recently used" signal that keeps it from being evicted.
         auto it = spriteCache.find(cacheKey);
         if (it != spriteCache.end()) {
-            return it->second;
+            spriteLru.splice(spriteLru.begin(), spriteLru, it->second.lru);
+            return it->second.sprite;
         }
 
         // Get the sprite ID for this form
@@ -106,7 +155,10 @@ namespace UI {
         }
 
         // Cache it (even if nullptr, so we don't keep trying to load missing sprites)
-        spriteCache[cacheKey] = sprite;
+        spriteLru.push_front(cacheKey);
+        spriteCache[cacheKey] = SpriteEntry{ sprite, spriteLru.begin() };
+        spriteBytes += bytesOf(sprite);
+        trimToBudget();   // stops at one entry, so the sprite being returned is never the one freed
 
         return sprite;
     }

--- a/src/UI/TrainerViewScreen.cpp
+++ b/src/UI/TrainerViewScreen.cpp
@@ -79,20 +79,25 @@ namespace UI {
         p->refreshChecksum();
     }
 
-    static std::unique_ptr<Pokemon::Pokemon> buildDefaultMon(Trainer::Trainer& tr, uint16_t species) {
+    // Origin version byte to stamp on a Pokemon created in this save. A game GROUP deliberately
+    // collapses a version pair into one value -- it exists to say "these games share a save format" --
+    // so picking the origin from it cannot tell Violet from Scarlet, and a created mon claimed the
+    // FIRST game of the pair (Violet -> Scarlet, Shield -> Sword, Shining Pearl -> Brilliant Diamond,
+    // Let's Go Eevee -> Let's Go Pikachu, LeafGreen -> FireRed). The title id knows exactly which game
+    // is open, and the enum's per-game values ARE the stored origin bytes, so it is used directly; the
+    // group only supplies a fallback for an id we don't recognise. Gen 3 stores origin in a 4-bit
+    // field, and both its values (FR = 4, LG = 5) fit, so distinguishing them is safe.
+    static uint8_t creatorOriginVersion(Trainer::Trainer& tr, u64 titleId) {
+        const Enums::GameVersion v = Enums::getGameVersion(titleId);
+        if (v != Enums::GameVersion::Invalid && Enums::getGameGroup(v) == tr.getGameGroup())
+            return static_cast<uint8_t>(v);
+        return Enums::getGroupRepVersion(tr.getGameGroup());
+    }
+
+    static std::unique_ptr<Pokemon::Pokemon> buildDefaultMon(Trainer::Trainer& tr, uint16_t species,
+                                                            uint8_t version) {
         auto p = tr.createBlankPokemon();
         if (!p) return p;
-        uint8_t version;  // origin = a representative version byte of the save's game group
-        switch (tr.getGameGroup()) {
-            case Enums::GameVersion::GG:   version = 42; break;  // Let's Go Pikachu
-            case Enums::GameVersion::BDSP: version = 48; break;  // Brilliant Diamond
-            case Enums::GameVersion::PLA:  version = 47; break;  // Legends: Arceus
-            case Enums::GameVersion::SV:   version = 50; break;  // Scarlet
-            case Enums::GameVersion::ZA:   version = 52; break;  // Legends: Z-A
-            case Enums::GameVersion::FRLG: version = 4;  break;  // FireRed -- Gen 3 origin is a 4-bit field,
-                                                                 // so 44 (Sword) would mangle to 12 (invalid)
-            default:                       version = 44; break;  // Sword (SWSH)
-        }
         const Pokemon::PersonalInfo& pi = Pokemon::getPersonalInfo(species, 0);
         p->setSpecies(species);          // first: drives the EXP growth rate + base-stat lookup
         p->setForm(0);
@@ -372,6 +377,18 @@ namespace UI {
     // SWSH/LZA (party is a separate structure -> getPartyPosition returns 0).
     bool TrainerViewScreen::storageSlotLocked(int pane, int box, int slot) {
         return pane == 0 && trainer.getPartyPosition(box, slot) > 0;
+    }
+
+    // The tail of the + handler: prompt about unsaved GAME-save changes, else leave. Split out so the
+    // bank's Save/Discard prompt can resume the exit once the user has answered it.
+    void TrainerViewScreen::beginAppExit() {
+        if (hasUnsavedChanges && !saveConfirmActive) {
+            exitingWithUnsavedChanges = true;
+            exitingViaPlus = true;   // remember we're exiting via the + button
+            saveConfirmActive = true;
+            return;
+        }
+        exitRequested = true;
     }
 
     // Convert `pk` in place into the format needed to live in `destPane`. The bank (pane 1) accepts
@@ -1327,25 +1344,24 @@ namespace UI {
 
         // Handle + button (exits application)
         if (kDown & HidNpadButton_Plus) {
-            // A carried Pokemon goes home, and the bank persists on its own before we leave.
+            // The bank question is already on screen -- answer that first rather than stacking a
+            // second exit on top of it.
+            if (storageExitConfirmActive) return;
+            // A carried Pokemon goes home before anything is weighed up.
             returnHeldToOrigin();
-            // If the bank can't be written, do NOT leave. Exiting anyway would silently discard every
-            // deposit made this session, and the user would only find out next launch. Staying costs
-            // one button press; leaving costs the data.
-            if (bank && !bank->save()) {
-                postStatus("Couldn't save the bank - NOT exiting, so nothing is lost. Check SD space.", 480);
+            // The bank is its own save file and gets its own decision. Closing the app is NOT that
+            // decision, so it must not write the bank on the way out: doing that committed every
+            // transfer even when the user went on to DECLINE the game save, and the two files then
+            // disagreed. A deposit became a permanent CLONE (the bank has it, the game save still
+            // has it), a withdrawal a permanent LOSS (the bank no longer has it, the game save was
+            // never written). Ask instead, and let Discard rewind both sides and write nothing.
+            if (bank && bank->hasChanged()) {
+                storageExitConfirmActive = true;
+                storageExitConfirmIndex = 0;
+                exitAfterBankChoice = true;   // resume this exit once they've answered
                 return;
             }
-            // Check for unsaved changes
-            if (hasUnsavedChanges && !saveConfirmActive) {
-                // Prompt to save changes before exiting
-                exitingWithUnsavedChanges = true;
-                exitingViaPlus = true;  // Remember we're exiting via + button
-                saveConfirmActive = true;
-                return;
-            }
-            // No unsaved changes or already handled, exit immediately
-            exitRequested = true;
+            beginAppExit();
             return;
         }
 
@@ -1382,7 +1398,8 @@ namespace UI {
                                    ? pickerOrder[pickerSel] : pickerSel;
                 if (sp > 0) {
                     storageSlot(creator.pane, creator.box, creator.slot) =
-                        buildDefaultMon(trainer, static_cast<uint16_t>(sp));
+                        buildDefaultMon(trainer, static_cast<uint16_t>(sp),
+                                        creatorOriginVersion(trainer, titleId));
                     hasUnsavedChanges = true;
                     pickerActive = false; creator.active = false;
                     openStorageEditor(creator.pane, creator.box, creator.slot);
@@ -2463,9 +2480,19 @@ namespace UI {
             if (tb >= 0) { storageExitConfirmIndex = tb; kDown |= HidNpadButton_A; }  // tap a row = select + confirm
             if (kDown & HidNpadButton_Up)   storageExitConfirmIndex = (storageExitConfirmIndex - 1 + N) % N;
             if (kDown & HidNpadButton_Down) storageExitConfirmIndex = (storageExitConfirmIndex + 1) % N;
-            if (kDown & HidNpadButton_B) { storageExitConfirmActive = false; return; }  // Cancel: stay
+            // Cancel: stay, and call off any app exit that raised this (they backed out of leaving too).
+            if (kDown & HidNpadButton_B) {
+                storageExitConfirmActive = false;
+                exitAfterBankChoice = false;
+                return;
+            }
             if (kDown & HidNpadButton_A) {
                 storageExitConfirmActive = false;
+                // Claimed up front, so a branch that bails out (a failed bank write) can't leave a
+                // stale "and then exit" hanging over the next visit to this prompt.
+                const bool resumeExit = exitAfterBankChoice;
+                exitAfterBankChoice = false;
+                bool answered = false;   // Save or Discard actually went through (Cancel did not)
                 switch (storageExitConfirmIndex) {
                     case 0:  // Save & Exit
                         // Same rule as the app-exit path: a failed bank write must not be followed by
@@ -2483,13 +2510,22 @@ namespace UI {
                                        " bank slot(s) failed the integrity check - see the PKSE log.", 480);
                         }
                         detailViewActive = false;
+                        answered = true;
                         break;
-                    case 1:  // Discard & Exit -> revert the in-memory bank to its on-disk state
+                    case 1:  // Discard & Exit -> revert the in-memory bank to its on-disk state.
+                             // ONLY the bank: it owns what lives in the bank, not what lives in the
+                             // save. Pulling a Pokemon out and then discarding therefore leaves the
+                             // copy in the save box -- intended, and what PKSM does. Undoing that half
+                             // is the GAME save's own discard, which is a separate decision.
                         if (bank) bank->load();
                         detailViewActive = false;
+                        answered = true;
                         break;
                     default: break;  // Cancel: stay in the storage view
                 }
+                // Raised by + rather than by B: the bank has had its answer, so carry on out of the
+                // app. Cancel leaves `answered` false and simply stays.
+                if (resumeExit && answered) beginAppExit();
                 return;
             }
             return;


### PR DESCRIPTION
- Sprite and texture caches grow without bound -- ~512 KB per unique Pokemon, never freed until exit. Closes #66
- Creator stamps the PAIRED version as Origin -- a Pokemon created in Violet says it came from Scarlet, etc. Closes #67
- `+` (exit app) saves the bank with NO prompt -- and does it BEFORE asking about the game save, so declining the game save leaves a permanently cloned (or destroyed) Pokemon. Closes #69