### PR TITLE
feat: editable trainer details — money and OT name across all 7 games

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ APP_AUTHOR  :=  Kiasta
 # single source of truth -- the two can no longer drift.
 # NOTE: no trailing comment on the assignment line. Make keeps trailing whitespace in a value, so
 # "0.0.3 \t\t# ..." would have baked spaces into the .nacp version and the -D define.
-APP_VERSION :=	1.0.3
+APP_VERSION :=	1.1.0
 ROMFS		:=	romfs
 ICON		:=  icon.jpg
 

--- a/include/Pokemon/Pokemon7LGPE.h
+++ b/include/Pokemon/Pokemon7LGPE.h
@@ -435,6 +435,18 @@ namespace Pokemon {
         /** Handling (current) Trainer name (0x78, 26 bytes). */
         std::u16string htName() const override { return getString(reinterpret_cast<const uint8_t*>(data.data() + 0x78), 26); }
         void setHTName(const std::u16string& value) noexcept override { setString(reinterpret_cast<uint8_t*>(data.data() + 0x78), 26, value, 12); refreshChecksum(); }
+        /** Handling Trainer gender (0 = Male, 1 = Female). Location: 0x92 (PKHeX PB7.HandlingTrainerGender),
+         *  directly before currentHandler below. This was the one HT field left on the base stub, and both
+         *  halves of that stub were wrong: the getter returned a hard 0, so every
+         *  handler displayed as Male whatever the save said, and the setter was a no-op, so a trainer gender
+         *  change could never re-stamp it. The re-stamp still counted those mons as updated (the getter's 0
+         *  never matched a Female trainer). */
+        uint8_t htGender() const noexcept override { return static_cast<uint8_t>(data[0x92]); }
+        void setHTGender(uint8_t value) noexcept override { data[0x92] = static_cast<std::byte>(value); refreshChecksum(); }
+        /** Handling Trainer friendship (0-255). Location: 0xA2. Wired alongside htGender -- same omission,
+         *  and an unwired getter that quietly returns 0 is what made the gender bug invisible. */
+        uint8_t htFriendship() const noexcept override { return static_cast<uint8_t>(data[0xA2]); }
+        void setHTFriendship(uint8_t value) noexcept override { data[0xA2] = static_cast<std::byte>(value); refreshChecksum(); }
         /** Current handler flag (0 = OT active, 1 = HT active). Location: 0x93. */
         uint8_t currentHandler() const noexcept override { return static_cast<uint8_t>(data[0x93]); }
         void setCurrentHandler(uint8_t value) noexcept override { data[0x93] = static_cast<std::byte>(value); refreshChecksum(); }

--- a/include/Trainer/Trainer.h
+++ b/include/Trainer/Trainer.h
@@ -419,6 +419,48 @@ namespace Trainer {
          */
         virtual bool canStoreBoxName(const std::string& name) const { (void)name; return true; }
 
+        // ========================================
+        // Editable Trainer Info
+        // ========================================
+
+        /**
+         * Serialize the editable trainer-identity fields (money, OT name) back into this
+         * save's blocks/buffer. Mirrors updateItemBlock()/updateBoxBlock() and MUST be called from the
+         * same place in each game's save function -- BEFORE that game's checksum/hash/encrypt pass,
+         * since these fields live inside the checksummed region.
+         *
+         * Each field is written to the SAME block+offset it was parsed from, so the value the editor
+         * shows round-trips exactly. Pure virtual so a new game can't drop trainer edits: a
+         * missing override is a compile error, not a quiet no-persist.
+         * 
+         * Editing gender is intentionally disabled ATM as it needs its own research and implementation.
+         */
+        virtual void updateTrainerInfoBlock() = 0;
+
+        /**
+         * Largest money value this game stores, for the money editor's clamp. Defaults to the modern
+         * cap (PKHeX SaveFile.MaxMoney = 9,999,999); Gen 3 overrides to 999,999 (PKHeX SAV3.MaxMoney).
+         */
+        virtual uint32_t getMaxMoney() const noexcept { return 9999999; }
+
+        /**
+         * Longest OT name this game accepts, in characters. Defaults to 12 (PKHeX MaxStringLengthTrainer
+         * for every Switch title); Gen 3 overrides to 7. The Gen-3 CHARACTER-SET limit is enforced
+         * separately via canStoreBoxName() (its ~70-glyph table is shared by box and trainer names).
+         */
+        virtual size_t getMaxTrainerNameLength() const noexcept { return 12; }
+
+        /**
+         * How many DIGITS a trainer name may contain -- a separate cap from the length, and one the
+         * games enforce at name entry. PKHeX TrainerNameVerifier.GetMaxNumberCount: no limit before
+         * gen 4, four in gens 4-5, five from gen 6 on. Every Switch title is gen 6+, so 5; Gen 3
+         * overrides to "no limit". Negative means unlimited.
+         *
+         * A name no longer than the cap is exempt, so "12345" is accepted on a cap of five while
+         * "123456" is not -- see nameHasTooManyDigits() in TrainerViewScreen.cpp.
+         */
+        virtual int getMaxTrainerNameDigits() const noexcept { return 5; }
+
     protected:
         /**
          * Default constructor for derived classes.

--- a/include/Trainer/Trainer3FRLG.h
+++ b/include/Trainer/Trainer3FRLG.h
@@ -79,6 +79,10 @@ namespace Trainer {
         size_t getMaxBoxNameLength() const noexcept override { return FRLG_BOX_NAME_CHARS; }
         bool canStoreBoxName(const std::string& name) const override;
         void updateItemBlock() override;
+        void updateTrainerInfoBlock() override;   // money / OT name
+        uint32_t getMaxMoney() const noexcept override { return 999999; }        // PKHeX SAV3.MaxMoney
+        size_t getMaxTrainerNameLength() const noexcept override { return 7; }   // PKHeX SAV3.MaxStringLengthTrainer
+        int getMaxTrainerNameDigits() const noexcept override { return -1; }     // no digit cap before gen 4
 
         std::unique_ptr<::Pokemon::Pokemon> createBlankPokemon() const override;
 

--- a/include/Trainer/Trainer7LGPE.h
+++ b/include/Trainer/Trainer7LGPE.h
@@ -132,6 +132,7 @@ namespace Trainer {
          * Updates the MY_ITEM block with modified inventory data.
          */
         void updateItemBlock() override;
+        void updateTrainerInfoBlock() override;   // money / OT name
 
         /**
          * Creates a species-0, checksum-valid blank PB7 entity via the encrypt->decrypt round-trip:

--- a/include/Trainer/Trainer8BDSP.h
+++ b/include/Trainer/Trainer8BDSP.h
@@ -27,7 +27,6 @@ namespace Trainer {
     constexpr size_t BDSP_MYSTATUS       = 0x79BB4;   // MyStatus8b; OT name (0x1A bytes) starts here
     constexpr size_t BDSP_ID32           = 0x79BD0;   // TID16 @ 0x79BD0 / SID16 @ 0x79BD2
     constexpr size_t BDSP_MONEY          = 0x79BD4;   // u32 (max 999,999)
-    constexpr size_t BDSP_GENDER         = 0x79BD8;   // Male byte (1 = male, 0 = female)
     constexpr size_t BDSP_ROMCODE        = 0x79BDF;   // BD = 0 / SP = 1
     constexpr size_t BDSP_HASH_OFFSET    = 0xE9818;   // MD5 (16 bytes) over the whole file, hash zeroed
     constexpr size_t BDSP_ITEM_BASE      = 0x0563C;   // MyItem8b: item i's 0x10 record at BASE + i*0x10
@@ -54,6 +53,8 @@ namespace Trainer {
         bool supportsBoxNames() const noexcept override { return true; }
         size_t getMaxBoxNameLength() const noexcept override { return BDSP_BOXNAME_LENGTH / 2 - 1; }
         void updateItemBlock() override;   // BDSP items deferred (no-op stub)
+        void updateTrainerInfoBlock() override;   // money / OT name
+        uint32_t getMaxMoney() const noexcept override { return 999999; }   // BDSP keeps the Gen-4 6-digit cap
         bool itemsAreIdIndexed() const override { return true; }   // count at BDSP_ITEM_BASE + itemId*stride
 
         // Species-0, checksum-valid blank PB8 (mirrors updateBoxBlock()'s encrypted-blank fallback:

--- a/include/Trainer/Trainer8LA.h
+++ b/include/Trainer/Trainer8LA.h
@@ -150,6 +150,7 @@ namespace Trainer {
          * Updates the ITEM_KEY block with modified inventory data.
          */
         void updateItemBlock() override;
+        void updateTrainerInfoBlock() override;   // money / OT name
 
         // Fixed-capacity packed pouches (KeyItems 100 / Stored 180 / Recipes 70), and the general
         // Items bag = min(675, SatchelUpgrades + 20). Enables in-pouch item creation for PLA.

--- a/include/Trainer/Trainer8SWSH.h
+++ b/include/Trainer/Trainer8SWSH.h
@@ -150,6 +150,7 @@ namespace Trainer {
          * Updates the ITEM_KEY block with modified inventory data.
          */
         void updateItemBlock() override;
+        void updateTrainerInfoBlock() override;   // money / OT name
 
         /**
          * Creates a species-0, checksum-valid blank PK8 entity (mirrors updateBoxBlock()'s

--- a/include/Trainer/Trainer9LZA.h
+++ b/include/Trainer/Trainer9LZA.h
@@ -149,6 +149,7 @@ namespace Trainer {
          * Updates the ITEM_KEY block with modified inventory data.
          */
         void updateItemBlock() override;
+        void updateTrainerInfoBlock() override;   // money / OT name
         bool itemsAreIdIndexed() const override { return true; }   // count at itemId * 0x10
 
         /**

--- a/include/Trainer/Trainer9SV.h
+++ b/include/Trainer/Trainer9SV.h
@@ -148,6 +148,7 @@ namespace Trainer {
          * Updates the ITEM_KEY block with modified inventory data.
          */
         void updateItemBlock() override;
+        void updateTrainerInfoBlock() override;   // money / OT name
         bool itemsAreIdIndexed() const override { return true; }   // count at itemId * 0x10
 
         /**

--- a/include/UI/TrainerViewScreen.h
+++ b/include/UI/TrainerViewScreen.h
@@ -116,6 +116,23 @@ namespace UI {
         // Selected row in the Settings view (0-4); reached from the menu's Settings icon.
         int settingsSelectedRow = 0;
 
+        // Trainer info view: the focused editable row (0 Name, 1 Money) and a
+        // one-frame-deferred edit request. Name/Money open the blocking swkbd; deferring one frame lets
+        // the row highlight render before the applet suspends the app (same trick as pendingHeaderRename).
+        // -1 = nothing pending.
+        int trainerSelectedRow = 0;
+        int pendingTrainerEdit = -1;
+        void editTrainerName();     // swkbd edit of the OT name (charset-validated, per-game length cap)
+        void editTrainerMoney();    // numpad edit of money (clamped to the game's max)
+        // After a name edit, re-stamp the trainer identity your Pokemon store so they stay
+        // recognized as yours (party + boxes; NOT the cross-game bank). Both the OT name AND the
+        // Gen 7+ handler (HT) name are part of the identity the games match on, so a bare trainer
+        // edit would make your caught mons read as traded (obedience / traded-EXP) and your traded-in
+        // mons lose you as their handler. Matches OT by ID32 + the carried OT name, and HT by the carried
+        // HT name (the HT format has no TID/SID). `caughtName` is the pre-rename name for a rename, the
+        // unchanged name otherwise; genuinely foreign stamps are untouched. Returns count changed.
+        int restampCaughtPokemonIdentity(const std::u16string& caughtName);
+
         // Box swap (Phase 3 3.1): press Y to grab the slot under the cursor, then Y on another
         // occupied slot to swap them. swapSourceBox/Slot record the grabbed slot.
         bool swapActive = false;

--- a/include/Utils/HelperUtilities.h
+++ b/include/Utils/HelperUtilities.h
@@ -28,6 +28,9 @@ namespace Utils {
     /// Helper to write little-endian uint32_t to a byte pointer.
     void writeUInt32LittleEndian(uint8_t* ptr, uint32_t value);
 
+    /// Helper to write little-endian uint64_t to a byte pointer.
+    void writeUInt64LittleEndian(uint8_t* ptr, uint64_t value);
+
     /// Returns a pseudo-random 32-bit value. Backed by a process-lifetime std::mt19937 seeded
     /// once from the libnx system tick. Used by the Pokemon creator for a new mon's PID /
     /// EncryptionConstant (a unique-per-call value is sufficient there).

--- a/src/Names/ItemNames.cpp
+++ b/src/Names/ItemNames.cpp
@@ -127,7 +127,7 @@ namespace Names {
         "Burn Drive",  // 118
         "Chill Drive",  // 119
         "???",  // 120
-        "Pokemon Box Link",  // 121
+        "Pokémon Box Link",  // 121
         "Medicine Pocket",  // 122
         "TM Case",  // 123
         "Candy Jar",  // 124
@@ -1081,7 +1081,7 @@ namespace Names {
         "???",  // 1072
         "???",  // 1073
         "Endorsement",  // 1074
-        "Pokemon Box Link",  // 1075
+        "Pokémon Box Link",  // 1075
         "Wishing Star",  // 1076
         "Dynamax Band",  // 1077
         "???",  // 1078

--- a/src/Save/GetSaveFileContents.cpp
+++ b/src/Save/GetSaveFileContents.cpp
@@ -219,6 +219,7 @@ namespace Save {
         delete[] file;
 
         // Patch edited blocks + recompute block checksums into the BEEF footer.
+        trainer.updateTrainerInfoBlock();   // money / OT name; mutates blocks before the copy
         writeBlocksToSaveData7LGPE(raw, trainer.getBlocks());
 
         // Write the full file to ModifiedSave/savedata.bin.
@@ -298,6 +299,7 @@ namespace Save {
         trainer.updateCurrentBoxBlock();
 
         // Encrypt the modified blocks (hash is calculated automatically)
+        trainer.updateTrainerInfoBlock();   // money / OT name; before the hash pass
         std::vector<uint8_t> encryptedData = encrypt(trainer.getBlocks());
 
         // Write to file
@@ -429,6 +431,7 @@ namespace Save {
         trainer.updateBoxBlock();
         trainer.updateBoxNameBlock();   // must precede this game's checksum/hash pass
         trainer.updateCurrentBoxBlock();
+        trainer.updateTrainerInfoBlock();   // money / OT name; before the MD5 hash pass
         trainer.recomputeHash();
         const std::vector<uint8_t>& saveData = trainer.getSaveData();
 
@@ -480,6 +483,7 @@ namespace Save {
         trainer.updateBoxBlock();
         trainer.updateBoxNameBlock();   // must precede this game's checksum/hash pass
         trainer.updateCurrentBoxBlock();
+        trainer.updateTrainerInfoBlock();   // money / OT name; before the hash pass
         std::vector<uint8_t> encryptedData = encrypt(trainer.getBlocks());
 
         char savePath[1024];
@@ -535,6 +539,7 @@ namespace Save {
         trainer.updateCurrentBoxBlock();
 
         // Encrypt the modified blocks (hash is calculated automatically)
+        trainer.updateTrainerInfoBlock();   // money / OT name; before the hash pass
         std::vector<uint8_t> encryptedData = encrypt(trainer.getBlocks());
 
         // Write to file
@@ -589,6 +594,7 @@ namespace Save {
         trainer.updateBoxBlock();
         trainer.updateBoxNameBlock();   // must precede this game's checksum/hash pass
         trainer.updateCurrentBoxBlock();
+        trainer.updateTrainerInfoBlock();   // money / OT name; before the hash pass
         std::vector<uint8_t> encryptedData = encrypt(trainer.getBlocks());
 
         char savePath[1024];
@@ -691,6 +697,7 @@ namespace Save {
         trainer.updateBoxNameBlock();   // must precede this game's checksum/hash pass
         trainer.updateCurrentBoxBlock();
         trainer.updatePartyBlock();
+        trainer.updateTrainerInfoBlock();   // money / OT name; before the sector checksums
         trainer.finalizeChecksums();
 
         const std::string name = trainer.fileName().empty() ? std::string("save.sav") : trainer.fileName();

--- a/src/Trainer/Trainer3FRLG.cpp
+++ b/src/Trainer/Trainer3FRLG.cpp
@@ -347,6 +347,19 @@ namespace Trainer {
         }
     }
 
+    void Trainer3FRLG::updateTrainerInfoBlock() {
+        // Raw sector-mapped save: OT name (g3-encoded, 7 chars @ 0x00) lives in the Small sector; money
+        // in the Large block at 0x290, XOR-keyed with the security key. finalizeChecksums() runs after.
+        // g3Encode writes 7 chars + a 0xFF terminator into 8 bytes, stopping before the gender byte at
+        // 0x08; the UI has already rejected any name the Gen-3 glyph table can't store.
+        const size_t sm = m_sectorOfs[SMALL_ID];
+        if (sm + 0x09 <= saveData.size())
+            g3Encode(this->trainerName, &saveData[sm + 0x00], 8, 7);
+        uint8_t moneyBuf[4];
+        writeUInt32LittleEndian(moneyBuf, this->money ^ m_key);
+        writeBlock(LARGE_ID, 0x290, moneyBuf, 4);
+    }
+
     void Trainer3FRLG::updateItemBlock() {
         const uint16_t key16 = static_cast<uint16_t>(m_key & 0xFFFF);
         for (size_t p = 0; p < items.size() && p < POUCH_COUNT3_FRLG; ++p) {
@@ -369,10 +382,8 @@ namespace Trainer {
                 writeBlock(LARGE_ID, pi.offset + slot * 4, entry, 4);
             }
         }
-        // Persist money (edited via trainer info); a no-op round-trip when unchanged.
-        uint8_t moneyBuf[4];
-        writeUInt32LittleEndian(moneyBuf, this->money ^ m_key);
-        writeBlock(LARGE_ID, 0x290, moneyBuf, 4);
+        // Money is written by updateTrainerInfoBlock(), which the save flow calls alongside this;
+        // keeping it there avoids a double-write of the same XOR-keyed value.
     }
 
     std::unique_ptr<::Pokemon::Pokemon> Trainer3FRLG::createBlankPokemon() const {

--- a/src/Trainer/Trainer7LGPE.cpp
+++ b/src/Trainer/Trainer7LGPE.cpp
@@ -561,6 +561,21 @@ namespace Trainer {
         return p;
     }
 
+    void Trainer7LGPE::updateTrainerInfoBlock()
+    {
+        // Write money / OT name back to the same blocks they are parsed from. Block CRC-16/ARC
+        // checksums are recomputed later by writeBlocksToSaveData7LGPE().
+        for (auto& block : blocks) {
+            if (block.key == MY_STATUS7_LGPE) {
+                if (block.data.size() >= 0x38 + 26)
+                    setString(&block.data[0x38], 26, utf8ToUtf16(trainerName), 12);   // OT name, 12 chars
+            } else if (block.key == MISC7_LGPE) {
+                if (block.data.size() >= 0x04 + 4)
+                    writeUInt32LittleEndian(&block.data[0x04], money);
+            }
+        }
+    }
+
     void Trainer7LGPE::updateItemBlock()
     {
         /**

--- a/src/Trainer/Trainer8BDSP.cpp
+++ b/src/Trainer/Trainer8BDSP.cpp
@@ -220,6 +220,16 @@ namespace Trainer {
         return p;
     }
 
+    void Trainer8BDSP::updateTrainerInfoBlock()
+    {
+        // Raw-buffer game: write straight into saveData (like updateItemBlock); recomputeHash() runs
+        // after.
+        if (saveData.size() < BDSP_MYSTATUS + 0x1A) return;
+        setString(&saveData[BDSP_MYSTATUS], 0x1A, utf8ToUtf16(trainerName), 12);
+        if (saveData.size() >= BDSP_MONEY + 4)
+            writeUInt32LittleEndian(&saveData[BDSP_MONEY], money);
+    }
+
     void Trainer8BDSP::updateItemBlock()
     {
         // Write each parsed item's count (int32) in place — non-destructive: touches only known items,

--- a/src/Trainer/Trainer8LA.cpp
+++ b/src/Trainer/Trainer8LA.cpp
@@ -80,7 +80,14 @@ namespace Trainer {
         size_t nameLength = 0x1A;  // 26 bytes = 13 UTF-16LE chars
         auto nameSpan = std::span<const uint8_t>(block.data.data() + 0x20, nameLength);
         this->trainerName = utf16ToUtf8(getString(nameSpan.data(), nameLength));
-        this->trainerGender = block.data[0x15] & 1;   // 0x15: gender (0=M, 1=F)
+        // The u32 at 0x3C identifies which of the eight preset characters the player chose at the start
+        // of the game, and that choice is also what fixes the gender -- PLA has no independent gender
+        // field. Bit 1 of the code is the gender (male codes 0,1,4,5 / female 2,3,6,7). Read from here
+        // rather than the plain 0/1 byte at 0x15, which is the value PKHeX calls "Gender".
+        if (block.data.size() >= 0x3C + 4) {
+            const uint32_t code = readUInt32LittleEndian(&block.data[0x3C]);
+            this->trainerGender = static_cast<uint8_t>((code >> 1) & 1);
+        }
         logInfoToFile("Parsed Trainer Name", this->trainerName.c_str());
     }
 
@@ -492,6 +499,20 @@ namespace Trainer {
             std::span<const std::byte>(enc, SIZE_PARTY8_LA));
         delete[] enc;
         return p;
+    }
+
+    void Trainer8LA::updateTrainerInfoBlock()
+    {
+        // Write money / OT name back to the blocks parse reads them from. encrypt() re-hashes.
+        for (auto& block : blocks) {
+            if (block.key == MY_STATUS8_LA) {
+                if (block.data.size() >= 0x20 + 0x1A)
+                    setString(&block.data[0x20], 0x1A, utf8ToUtf16(trainerName), 12);
+            } else if (block.key == MONEY8_LA) {
+                if (block.data.size() >= 4)
+                    writeUInt32LittleEndian(block.data.data(), money);   // MONEY8_LA is a u32 scalar block
+            }
+        }
     }
 
     void Trainer8LA::updateItemBlock()

--- a/src/Trainer/Trainer8SWSH.cpp
+++ b/src/Trainer/Trainer8SWSH.cpp
@@ -544,6 +544,21 @@ namespace Trainer {
         return p;
     }
 
+    void Trainer8SWSH::updateTrainerInfoBlock()
+    {
+        // OT name (0xB0) goes back into MyStatus8; money into its own block -- the same authoritative
+        // places parse reads them, so edits take effect in-game. encrypt() re-hashes.
+        for (auto& block : blocks) {
+            if (block.key == MY_STATUS8_SWSH) {
+                if (block.data.size() >= 0xB0 + 0x1A)
+                    setString(&block.data[0xB0], 0x1A, utf8ToUtf16(trainerName), 12);
+            } else if (block.key == MONEY8_SWSH) {
+                if (block.data.size() >= 0x04 + 4)
+                    writeUInt32LittleEndian(&block.data[0x04], money);
+            }
+        }
+    }
+
     void Trainer8SWSH::updateItemBlock()
     {
         /**

--- a/src/Trainer/Trainer9LZA.cpp
+++ b/src/Trainer/Trainer9LZA.cpp
@@ -548,6 +548,20 @@ namespace Trainer {
         return p;
     }
 
+    void Trainer9LZA::updateTrainerInfoBlock()
+    {
+        // Write money / OT name back to the blocks parse reads them from. encrypt() re-hashes.
+        for (auto& block : blocks) {
+            if (block.key == MY_STATUS9_LZA) {
+                if (block.data.size() >= 0x10 + 0x1A)
+                    setString(&block.data[0x10], 0x1A, utf8ToUtf16(trainerName), 12);
+            } else if (block.key == MONEY9_LZA) {
+                if (block.data.size() >= 4)
+                    writeUInt32LittleEndian(block.data.data(), money);   // MONEY9_LZA is a u32 scalar block
+            }
+        }
+    }
+
     void Trainer9LZA::updateItemBlock()
     {
         /**

--- a/src/Trainer/Trainer9SV.cpp
+++ b/src/Trainer/Trainer9SV.cpp
@@ -547,6 +547,20 @@ namespace Trainer {
         return p;
     }
 
+    void Trainer9SV::updateTrainerInfoBlock()
+    {
+        // Write money / OT name back to the blocks parse reads them from. encrypt() re-hashes.
+        for (auto& block : blocks) {
+            if (block.key == MY_STATUS9_SV) {
+                if (block.data.size() >= 0x10 + 0x1A)
+                    setString(&block.data[0x10], 0x1A, utf8ToUtf16(trainerName), 12);
+            } else if (block.key == MONEY9_SV) {
+                if (block.data.size() >= 4)
+                    writeUInt32LittleEndian(block.data.data(), money);   // MONEY9_SV is a u32 scalar block
+            }
+        }
+    }
+
     void Trainer9SV::updateItemBlock()
     {
         /**

--- a/src/UI/Dialogs/PickerDialog.cpp
+++ b/src/UI/Dialogs/PickerDialog.cpp
@@ -165,7 +165,7 @@ namespace Dialogs {
             } else {
                 label = pickerOptionLabel(kind, val);
             }
-            fb.drawText(px + 28, ry + 8, label, col);
+            fb.drawText(px + 28, ry + (rowH - 4 - fb.lineHeight(TextStyle::Body)) / 2, label, col);
             screen.touchButtons.push_back({ idx, px + 12, ry, pw - 24, rowH - 4 });  // id = option row
         }
 

--- a/src/UI/Modals/PokemonDetailsModal.cpp
+++ b/src/UI/Modals/PokemonDetailsModal.cpp
@@ -198,6 +198,14 @@ namespace Modals {
             else          snprintf(buf, sizeof(buf), "%05u", p->id32() & 0xFFFFu);
             row("OT ID", buf);
         }
+        // Handling Trainer (Gen 7+): shown only once a mon has actually been handled by someone (htName
+        // non-empty), like the OT row above. This makes the OT/HT re-stamp verifiable on-device --
+        // change trainer gender/name, reopen a traded-in mon, and HT should track you. FireRed/LeafGreen
+        // has no handler concept, so htName() is empty there and this row stays hidden.
+        {
+            std::string ht = utf16ToUtf8(p->htName());
+            if (!ht.empty()) { ht += (p->htGender() == 0) ? " (M)" : " (F)"; row("HT", ht); }
+        }
         { snprintf(buf, sizeof(buf), "Lv. %u", p->metLevel()); editRow("Met Lv", buf, 18); }
         // Origin-generation location routing: a Gen 3/4 mon's MET id is remapped into the current
         // format's numbering when it is transferred up (Gen 5+ keep their own table), so a Gen 3/4 met

--- a/src/UI/TrainerViewScreen.cpp
+++ b/src/UI/TrainerViewScreen.cpp
@@ -269,7 +269,9 @@ namespace UI {
         fb.drawText(rx, ry + 8, "A: toggle     B: back", Colors::TextDim, TextStyle::Caption);
     }
 
-    // Trainer view (HOME-style ID card), reached from the HOME menu's Trainer icon.
+    // Trainer view (HOME-style ID card), reached from the HOME menu's Trainer icon. The first two
+    // rows (Name / Money) are editable; the rows below are informational -- editing TID/SID would
+    // re-own every Pokemon already in the save, so it is deliberately left out.
     static void drawTrainerView(TrainerViewScreen& screen, PKSEFramebuffer& fb, int x, int y, int w, int h) {
         Trainer::Trainer& t = screen.trainer;
         fb.drawFilledRoundedRect(x, y, w, h, 16, Colors::Panel);
@@ -279,26 +281,52 @@ namespace UI {
         fb.drawFilledRect(x, y + hH - 16, w, 16, Colors::AccentDim);
         fb.drawText(x + 22, y + (hH - fb.lineHeight(TextStyle::Heading)) / 2, "Trainer", Colors::Text, TextStyle::Heading);
 
-        const int cardW = 640, cardX = x + (w - cardW) / 2;
-        int cy = y + hH + 34;
-        { int nw, nh; fb.measureText(t.trainerName, nw, nh, TextStyle::Title);
-          fb.drawText(cardX + (cardW - nw) / 2, cy, t.trainerName, Colors::Text, TextStyle::Title);
-          cy += nh + 12; }
-        fb.drawHDivider(cardX + 20, cy, cardW - 40);
-        cy += 22;
+        screen.touchButtons.clear();
 
-        auto row = [&](const char* label, const std::string& value, Color vc) {
-            fb.drawSoftShadow(cardX, cy, cardW, 52, 12);
-            fb.drawFilledRoundedRect(cardX, cy, cardW, 52, 12, Colors::PanelAlt);
-            fb.drawText(cardX + 24, cy + (52 - fb.lineHeight(TextStyle::Body)) / 2, label, Colors::TextDim, TextStyle::Body);
-            int vw, vh; fb.measureText(value, vw, vh, TextStyle::Body);
-            fb.drawText(cardX + cardW - 24 - vw, cy + (52 - vh) / 2, value, vc, TextStyle::Body);
-            cy += 62;
+        const int cardW = 680, cardX = x + (w - cardW) / 2;
+        int cy = y + hH + 26;
+
+        // --- Editable rows (Name / Money): selectable via cursor + touch, styled like Settings.
+        // Gender is display-only, so it sits with the identity rows below rather than leaving a hole
+        // the cursor has to jump over. ---
+        constexpr int kEditRows = 2;
+        const char* labels[kEditRows] = { "Name", "Money" };
+        const std::string values[kEditRows] = {
+            t.trainerName.empty() ? "(none)" : t.trainerName,
+            "$" + std::to_string(t.money),
         };
-        row("Trainer ID", std::to_string(t.TID16) + " / " + std::to_string(t.SID16), Colors::Text);
-        row("Full TID", std::to_string(t.TID), Colors::Text);
-        row("Full SID", std::to_string(t.SID), Colors::Text);
-        row("Money", "$" + std::to_string(t.money), Colors::Primary);
+        const int rowH = 60;
+        for (int i = 0; i < kEditRows; ++i) {
+            const bool sel = (screen.trainerSelectedRow == i);
+            fb.drawSoftShadow(cardX, cy, cardW, rowH, 14);
+            fb.drawFilledRoundedRect(cardX, cy, cardW, rowH, 14, sel ? Colors::Selected : Colors::PanelAlt);
+            if (sel) fb.drawRoundedRect(cardX, cy, cardW, rowH, 14, Colors::Accent, 2);
+            fb.drawText(cardX + 24, cy + (rowH - fb.lineHeight(TextStyle::Body)) / 2, labels[i], Colors::TextDim, TextStyle::Body);
+            int vw, vh; fb.measureText(values[i], vw, vh, TextStyle::Body);
+            const int pillW = vw + 44, pillH = 38;
+            const int px = cardX + cardW - pillW - 20, py = cy + (rowH - pillH) / 2;
+            fb.drawPill(px, py, pillW, pillH, sel ? Colors::Primary : Colors::Background);
+            fb.drawText(px + (pillW - vw) / 2, py + (pillH - vh) / 2, values[i], sel ? Colors::PrimaryText : Colors::Text, TextStyle::Body);
+            screen.touchButtons.push_back({ i, cardX, cy, cardW, rowH });
+            cy += rowH + 14;
+        }
+
+        cy += 6;
+        fb.drawHDivider(cardX + 20, cy, cardW - 40);
+        cy += 20;
+
+        // --- Read-only rows (not selectable). ---
+        auto infoRow = [&](const char* label, const std::string& value) {
+            fb.drawFilledRoundedRect(cardX, cy, cardW, 46, 12, Colors::PanelAlt);
+            fb.drawText(cardX + 24, cy + (46 - fb.lineHeight(TextStyle::Body)) / 2, label, Colors::TextDim, TextStyle::Body);
+            int vw, vh; fb.measureText(value, vw, vh, TextStyle::Body);
+            fb.drawText(cardX + cardW - 24 - vw, cy + (46 - vh) / 2, value, Colors::Text, TextStyle::Body);
+            cy += 54;
+        };
+        infoRow("Gender", t.trainerGender == 0 ? "Male" : "Female");
+        infoRow("Trainer ID", std::to_string(t.TID16) + " / " + std::to_string(t.SID16));
+        infoRow("Full TID", std::to_string(t.TID));
+        infoRow("Full SID", std::to_string(t.SID));
     }
 
     TrainerViewScreen::TrainerViewScreen(Trainer::Trainer& trainer, const std::string& titleName, const std::string& backupDir, u64 titleId, AccountUid userUid, bool loadedFromCart)
@@ -705,6 +733,111 @@ namespace UI {
         storageStatus = res.text.empty() ? "Bank box name reset to default."
                                          : ("Bank box renamed to \"" + res.text + "\".");
         storageStatusFrames = 180;
+    }
+
+    // Re-stamp the trainer identity your Pokemon store after a name edit, so they stay
+    // recognized as yours (see the header). Two independent matches per mon:
+    //   (1) OT  -- you caught it: match OT ID32 + the carried OT name.
+    //   (2) HT  -- it was traded to you (Gen 7+): match the carried HT name (HT has no TID/SID).
+    // Genuinely foreign stamps (someone else's OT/HT) are left untouched. Walks party + boxes only --
+    // the cross-game bank is deliberately excluded. Returns the count of mons actually changed.
+    int TrainerViewScreen::restampCaughtPokemonIdentity(const std::u16string& caughtName) {
+        const std::u16string newName = Utils::utf8ToUtf16(trainer.trainerName);
+        const uint8_t newGender = trainer.trainerGender;
+        const uint32_t id32 = trainer.ID32;
+        int changed = 0;
+        auto restamp = [&](Pokemon::Pokemon* pk) {
+            if (!pk || pk->speciesID() == 0) return;
+            bool did = false;
+            // (1) You are the ORIGINAL TRAINER.
+            if (pk->id32() == id32 && pk->otName() == caughtName) {
+                if (pk->otName()   != newName)   { pk->setOTName(newName);     did = true; }
+                if (pk->otGender() != newGender) { pk->setOTGender(newGender); did = true; }
+            }
+            // (2) You are the HANDLING TRAINER of a traded-in mon. FRLG has no HT (htName() is empty),
+            // so it never matches; the empty guard also stops untraded mons (empty HT) matching a
+            // cleared trainer name.
+            if (!caughtName.empty() && pk->htName() == caughtName) {
+                if (pk->htName()   != newName)   { pk->setHTName(newName);     did = true; }
+                if (pk->htGender() != newGender) { pk->setHTGender(newGender); did = true; }
+            }
+            // Trainer fields don't affect stats, so refresh the checksum only (no recalculateStats).
+            if (did) { pk->refreshChecksum(); ++changed; }
+        };
+        for (auto& pk : trainer.party) restamp(pk.get());
+        for (auto& box : trainer.boxes)
+            for (auto& pk : box) restamp(pk.get());
+        return changed;
+    }
+
+    // Append " Updated OT on N of your Pokemon." to a status line when a re-stamp touched any.
+    static std::string withOtRestampNote(std::string msg, int n) {
+        if (n > 0) msg += " Updated OT on " + std::to_string(n) + " of your Pokemon.";
+        return msg;
+    }
+
+    // Edit the trainer's OT name via the Switch keyboard. Mirrors renameBox: a cancel leaves the
+    // name untouched, an unchanged result is a no-op, and a name the game's glyph table can't store is
+    // refused rather than silently mangled (Gen 3 has ~70 glyphs; canStoreBoxName is the shared check).
+    // Mirrors PKHeX TrainerNameVerifier.ContainsTooManyNumbers. The games cap how many digits a
+    // trainer name may hold, separately from its length, and a name no longer than the cap is
+    // exempt -- so a five-digit cap accepts "12345" but not "123456". Counts characters rather than
+    // bytes (the name is UTF-8 here) and treats full-width digits as digits, matching .NET's
+    // char.IsNumber, since a Japanese keyboard produces those.
+    static bool nameHasTooManyDigits(const std::u16string& name, int maxDigits) {
+        if (maxDigits < 0) return false;                                  // generation with no cap
+        if (name.size() <= static_cast<size_t>(maxDigits)) return false;  // short enough to be exempt
+        int digits = 0;
+        for (char16_t c : name) {
+            if ((c >= u'0' && c <= u'9') || (c >= 0xFF10 && c <= 0xFF19))
+                ++digits;
+        }
+        return digits > maxDigits;
+    }
+
+    void TrainerViewScreen::editTrainerName() {
+        const std::string current = trainer.trainerName;
+        const Utils::KeyboardResult res =
+            Utils::promptText("Trainer Name", "OT name", current,
+                              static_cast<int>(trainer.getMaxTrainerNameLength()));
+        if (!res.accepted) return;          // cancel means "leave it alone", not "clear it"
+        if (res.text == current) return;
+        if (!trainer.canStoreBoxName(res.text)) {
+            Utils::logTest("TRAINERNAME new=\"" + res.text + "\" result=REFUSED_CHARSET");
+            postStatus("This game can't store those characters (A-Z, 0-9, and ! ? . - only).", 240);
+            return;
+        }
+        const int maxDigits = trainer.getMaxTrainerNameDigits();
+        if (nameHasTooManyDigits(Utils::utf8ToUtf16(res.text), maxDigits)) {
+            Utils::logTest("TRAINERNAME new=\"" + res.text + "\" result=REFUSED_DIGITS");
+            postStatus("This game allows at most " + std::to_string(maxDigits) +
+                       " numbers in a trainer name.", 240);
+            return;
+        }
+        Utils::logTest("TRAINERNAME old=\"" + current + "\" new=\"" + res.text + "\" result=OK");
+        // Match owned mons by the name they currently carry (the pre-rename name) BEFORE we change it.
+        const std::u16string caughtName = Utils::utf8ToUtf16(current);
+        trainer.trainerName = res.text;
+        const int n = restampCaughtPokemonIdentity(caughtName);
+        hasUnsavedChanges = true;
+        Utils::logTest("TRAINERNAME restamped=" + std::to_string(n));
+        postStatus(withOtRestampNote(res.text.empty() ? "Trainer name cleared." : "Trainer name updated.", n), 200);
+    }
+
+    // Edit the trainer's money via the number pad, clamped to this game's cap. promptNumber both
+    // widths the keypad to the max and clamps the returned value, so an out-of-range entry can't slip in.
+    void TrainerViewScreen::editTrainerMoney() {
+        const Utils::NumberResult res =
+            Utils::promptNumber("Money", static_cast<int>(trainer.money), 0,
+                                static_cast<int>(trainer.getMaxMoney()));
+        if (!res.accepted) return;
+        const uint32_t newMoney = static_cast<uint32_t>(res.value);
+        if (newMoney == trainer.money) return;
+        Utils::logTest("TRAINERMONEY old=" + std::to_string(trainer.money) +
+                       " new=" + std::to_string(newMoney) + " result=OK");
+        trainer.money = newMoney;
+        hasUnsavedChanges = true;
+        postStatus("Money set to $" + std::to_string(newMoney) + ".", 150);
     }
 
     // A backup's leaf folder name IS its name everywhere in the UI (PKSM does the same), so this is
@@ -1339,6 +1472,16 @@ namespace UI {
             } else {
                 renameBox(selectedBoxIndex);
             }
+            return;
+        }
+
+        // A trainer-info row (Name/Money) was activated last frame; open its blocking keyboard now that
+        // the row highlight has had a frame to draw.
+        if (pendingTrainerEdit >= 0) {
+            const int row = pendingTrainerEdit;
+            pendingTrainerEdit = -1;
+            if (row == 0)      editTrainerName();
+            else if (row == 1) editTrainerMoney();
             return;
         }
 
@@ -3026,6 +3169,20 @@ namespace UI {
                 }
             }
 
+            // Trainer info view: Name (0) / Money (1). Gender is read-only and lives with the
+            // identity rows below, so it is not in this list at all. Both rows defer one frame so
+            // the row highlight draws before the blocking swkbd opens.
+            if (selectedMode == ViewMode::Trainer) {
+                constexpr int kEditRows = 2;
+                int tb = touchedButtonId(touch);
+                if (tb >= 0 && tb < kEditRows) { trainerSelectedRow = tb; kDown |= HidNpadButton_A; }
+                if (kDown & HidNpadButton_Up)   trainerSelectedRow = (trainerSelectedRow - 1 + kEditRows) % kEditRows;
+                if (kDown & HidNpadButton_Down) trainerSelectedRow = (trainerSelectedRow + 1) % kEditRows;
+                if (kDown & HidNpadButton_A) {
+                    pendingTrainerEdit = trainerSelectedRow;   // Name (0) / Money (1): open swkbd next frame
+                }
+            }
+
             // Settings view: Up/Down select a row, A toggles it (0 = auto-backup, 1 = theme,
             // 2 = allow illegal values, 3 = Let's Go move warning, 4 = inject backups to game save).
             if (selectedMode == ViewMode::Settings) {
@@ -3395,7 +3552,8 @@ namespace UI {
                     instructions = "Arrows: Move  |  A: Select  |  Minus: Options  |  Y: Mode (Multi)  |  X: Sort Box  |  B: Clear";
                 }
             } else if (selectedMode == ViewMode::Trainer) {
-                instructions = "B: Back  |  +: Exit App";
+                // X saves only from the HOME menu (see the X handler), so the flow is edit -> B -> X.
+                instructions = "Up/Down: Select  |  A: Edit  |  B: Back  |  +: Exit App";
             }
         } else {
             // HOME main menu.

--- a/src/Utils/HelperUtilities.cpp
+++ b/src/Utils/HelperUtilities.cpp
@@ -56,6 +56,11 @@ namespace Utils {
         ptr[3] = static_cast<uint8_t>((value >> 24) & 0xFF);
     }
 
+    void writeUInt64LittleEndian(uint8_t* ptr, uint64_t value) {
+        for (int i = 0; i < 8; ++i)
+            ptr[i] = static_cast<uint8_t>((value >> (i * 8)) & 0xFF);
+    }
+
     uint32_t rand32() noexcept {
         // Process-lifetime Mersenne Twister, seeded once from libnx's system tick counter
         // (armGetSystemTick, a u64). The high and low halves are folded together so all of the


### PR DESCRIPTION
Money and OT name are now editable on the Trainer screen for FR/LG, Let's Go, SwSh, BDSP, Legends: Arceus, S/V and Legends: Z-A.

Trainer identity stays consistent across a rename:
- OT re-stamp — your own caught Pokemon keep matching you, so they are not re-read as traded (FR/LG obedience, the traded-EXP bonus, and so on).
- HT re-stamp — Pokemon traded to you (Gen 7+) keep you as their handler. The details modal now shows OT and HT rows, so a re-stamp can be confirmed on-device without pulling the save.

Name validation follows each game's own rules:
- Gen 3 charset is enforced; a name the game cannot store is refused outright rather than written mangled.
- Digit cap ported from PKHeX TrainerNameVerifier.ContainsTooManyNumbers. A name no longer than the cap is exempt, matching PKHeX. The refusal is unconditional and is not overridden by "allow illegal values".

Read-path bugs found along the way:
- SwSh read the OT name from the Trainer Card block and the gender from a wrong byte inside it. Both now come from MyStatus8 (name 0xB0, gender 0xA5), matching PKHeX.
- S/V and Legends: Z-A truncated the OT name to 8 characters; the field is really 26 bytes, or 12 characters.

Trainer gender is read and displayed but not editable. The trainer record and the character model are stored separately in SwSh, BDSP, Legends: Arceus and S/V, and worn clothing is gender-specific in each, so changing the record leaves a save holding items the model has no version of.

Closes #54