### PR TITLE
feat: HOME-style rectangle select and carry in the bank, shared with …

### DIFF
--- a/include/Names/LocationNames.h
+++ b/include/Names/LocationNames.h
@@ -7,7 +7,7 @@
  * see Enums::GameVersion).
  *
  * IDs are BANKED (id / 10000): bank 0 = in-world locations, bank 3 (30000) =
- * Link Trade / region + Pokemon HOME/GO transfers, bank 4 (40000) = events,
+ * Link Trade / region + HOME/GO transfers, bank 4 (40000) = events,
  * bank 6 (60000) = egg received-from sources. A traded/transferred/egg mon
  * therefore has a high-banked id; resolving only bank 0 renders it "(none)".
  * Tables are extracted from PKHeX's met-location text resources and the lookup

--- a/include/Trainer/Bank.h
+++ b/include/Trainer/Bank.h
@@ -1,7 +1,7 @@
 /**
  * Bank.h - Persistent cross-GAME Pokemon storage ("bank")
  *
- * A PKSM-style storage bank: boxes of Pokemon that live OUTSIDE any single save file,
+ * A HOME-style storage bank: boxes of Pokemon that live OUTSIDE any single save file,
  * persisted to the SD card under sdmc:/PKSE/bank. UNIFIED across all games: every slot
  * carries its own game-group tag + native (encrypted) per-gen bytes, so Pokemon from all
  * six titles coexist in one bank. Deposit is passive (store as-is, byte-in == byte-out) --
@@ -38,7 +38,7 @@ namespace Trainer {
         bool save() const;
 
         /// True if the in-memory boxes differ from the last saved/loaded on-disk state.
-        /// Used to prompt Save/Discard when leaving the storage view (PKSM-style).
+        /// Used to prompt Save/Discard when leaving the storage view (HOME-style).
         bool hasChanged() const;
 
         size_t boxCount() const noexcept { return BANK_BOX_COUNT; }

--- a/include/UI/Common.h
+++ b/include/UI/Common.h
@@ -49,9 +49,15 @@ namespace UI {
         // Attention accent for warning dialog titles ("Unsaved Changes", "Delete Backup?"). Theme-aware
         // because a bright amber that reads on the dark UI is nearly invisible on light-mode white.
         inline Color Warning      = Color(255, 199, 66);
-        // Shiny marker (star / "Yes"), PKSM-style red rather than yellow. Theme-aware: yellow washed
+        // Shiny marker (star / "Yes"), HOME-style red rather than yellow. Theme-aware: yellow washed
         // out on light-mode white exactly like Warning did, and red reads on both sprites and panels.
         inline Color ShinyStar    = Color(255, 96, 86);
+        // Storage cursor-mode colors, one per CursorMode — a red/blue/green scheme across the three
+        // pointer arrows (Menu / Move / Multi). Theme-aware: the light variants are deepened so
+        // the arrow, the selection wash and the carried-block backing still read against a white panel.
+        inline Color CursorMenu   = Color(232, 92, 92);
+        inline Color CursorMove   = Color(86, 148, 244);
+        inline Color CursorMulti  = Color(96, 205, 128);
 
         // Let's Go specific colors (matching in-game UI) — theme-independent
         constexpr Color PartnerHeart(255, 105, 180);    // Hot pink heart for Partner Pokemon
@@ -61,6 +67,12 @@ namespace UI {
         constexpr Color PartyBadge(255, 193, 68);
         constexpr Color PartyBadgeText(38, 28, 8);
     }
+
+    // Height of the arrowhead on the storage/box grid cursor, in framebuffer pixels. Absolute
+    // rather than a fraction of the disc, because the two grids size their discs differently (the
+    // Boxes view has more room per cell than the bank's paired panes) -- scaling off the disc gave
+    // a visibly bigger cursor in one view than the other.
+    constexpr int kGridCursorH = 32;
 
     // Minimum comfortable touch-target size in framebuffer pixels. The UI renders at 1280x720 on
     // the ~6" handheld screen, so tappable controls (menu rows, dialog buttons, tab/nav hit areas)
@@ -90,6 +102,9 @@ namespace UI {
             PrimaryText= Color(43, 32, 10);
             Warning    = Color(255, 199, 66);   // bright gold, reads on the dark UI
             ShinyStar  = Color(255, 96, 86);    // warm coral-red on the dark UI
+            CursorMenu = Color(232, 92, 92);
+            CursorMove = Color(86, 148, 244);
+            CursorMulti= Color(96, 205, 128);
         } else { // Light
             Background = Color(241, 241, 246);
             Panel      = Color(255, 255, 255);
@@ -104,6 +119,9 @@ namespace UI {
             PrimaryText= Color(43, 32, 10);
             Warning    = Color(176, 98, 0);     // deep amber, reads on light-mode white
             ShinyStar  = Color(202, 44, 38);    // deep red, reads on light-mode white
+            CursorMenu = Color(206, 58, 58);
+            CursorMove = Color(38, 106, 214);
+            CursorMulti= Color(38, 150, 84);
         }
     }
 }

--- a/include/UI/PKSEFramebuffer.h
+++ b/include/UI/PKSEFramebuffer.h
@@ -61,7 +61,7 @@ namespace UI {
         void drawHDivider(int x, int y, int w);                   // subtle horizontal rule
         void drawFilledEllipse(int cx, int cy, int rx, int ry, Color color);  // e.g. soft shadows
 
-        // --- Rounded / vector primitives (Pokemon HOME look, Phase 4) ---
+        // --- Rounded / vector primitives (HOME look, Phase 4) ---
         // Anti-aliased on the horizontal edges of rounded corners (fractional coverage);
         // straight edges are exact. `r` is the corner radius (clamped to min(w,h)/2).
         void drawFilledRoundedRect(int x, int y, int w, int h, int r, Color color);
@@ -71,10 +71,15 @@ namespace UI {
         // Draws a Pokemon egg (cream oval + teal spots) centered at (cx,cy), ~size px tall.
         // Used in the box/storage grids in place of the species sprite when a mon is an egg.
         void drawEgg(int cx, int cy, int size);
-        // Draws Pokemon HOME's shiny mark -- a four-pointed sparkle (concave-sided star) --
+        // Draws HOME's shiny mark -- a four-pointed sparkle (concave-sided star) --
         // filling a size×size box whose top-left is (x,y), so it drops into existing marker
         // rows the same way drawSymbol did. Replaces the old ★ glyph everywhere shiny is shown.
         void drawShinyMark(int x, int y, int size, Color color);
+        // Storage-grid cursor: a wide arrowhead pointing straight down, no shaft. Its POINT lands on
+        // (tipX, tipY) with the head above, symmetric about that x. `headHeight` sizes the head --
+        // the visible arrow; the mitred outline runs on below it to the point at tipY, adding ~27%
+        // more. Drawn in the active cursor mode's colour.
+        void drawPointerCursor(int tipX, int tipY, int headHeight, Color color);
         // Stadium (fully-rounded) pill = rounded rect with r = h/2. HOME's headers/badges/buttons.
         void drawPill(int x, int y, int w, int h, Color color);
         void drawPillBorder(int x, int y, int w, int h, Color color, int thickness = 1);
@@ -89,9 +94,6 @@ namespace UI {
                              float maxValue, Color fill, Color web, Color outline);
         // Two-tone rounded type badge (HOME style): colored icon chip + name. Returns total width drawn.
         int  drawTypeBadge(int x, int y, const std::string& typeName, Color typeColor);
-        // Rounded name-label with a downward triangle tail — HOME's box-grid selection cursor.
-        void drawNameCursorLabel(int cx, int topY, const std::string& text, Color fill, Color textColor);
-
         // Draw a sprite with a gentle idle animation (bob + breathe) and a soft ground
         // shadow, driven by the frame tick. (x,y,boxW,boxH) is the nominal placement box;
         // (srcW,srcH) the sprite's native size; `phase` offsets the timing per sprite.

--- a/include/UI/Panels/CarriedSprite.h
+++ b/include/UI/Panels/CarriedSprite.h
@@ -1,0 +1,44 @@
+#ifndef UI_PANELS_CARRIED_SPRITE_H
+#define UI_PANELS_CARRIED_SPRITE_H
+
+#include <algorithm>
+#include <string>
+
+#include "UI/Common.h"
+#include "UI/PKSEFramebuffer.h"
+#include "UI/SpriteManager.h"
+#include "Pokemon/Pokemon.h"
+
+namespace UI {
+    namespace Panels {
+        /**
+         * Draw a Pokemon lifted off the board: a soft ground shadow where it would land, plus the
+         * sprite raised above it.
+         *
+         * Shared by the bank's carried block and the Boxes view's grabbed Pokemon, so "picked up"
+         * looks identical in both. The two views reach this state by different routes -- the bank
+         * genuinely moves the Pokemon out of its slot into `moveMon`, while the Boxes view leaves it
+         * in place and only marks its slot -- but from the player's side both should read the same:
+         * the slot it came from looks empty and the Pokemon travels with the cursor.
+         */
+        inline void drawLiftedMon(PKSEFramebuffer& fb, const ::Pokemon::Pokemon* pk,
+                                  int cx, int cy, int discR) {
+            if (!pk || pk->speciesID() == 0) return;
+            const int sz = static_cast<int>(discR * 1.75);
+            const int lift = std::max(6, discR / 4);
+            fb.drawFilledEllipse(cx, cy + discR - 2, sz / 2 - 4, 5, Color(0, 0, 0, 90));
+            if (pk->isEgg()) {
+                fb.drawEgg(cx, cy - lift, sz);
+                return;
+            }
+            const bool shiny = pk->isShiny(pk->id32(), std::string(pk->species()));
+            Sprite* sprite = SpriteManager::getIconSprite(pk->speciesID(), pk->form(), shiny);
+            if (sprite && sprite->data)
+                fb.drawImageScaled(cx - sz / 2, cy - lift - sz / 2, sprite->width, sprite->height,
+                                   sz, sz, sprite->data, sprite->channels);
+            if (shiny) fb.drawShinyMark(cx + discR - 15, cy - lift - discR + 1, 15, Colors::ShinyStar);
+        }
+    }
+}
+
+#endif

--- a/include/UI/Panels/HomeMenuPanel.h
+++ b/include/UI/Panels/HomeMenuPanel.h
@@ -9,7 +9,7 @@ namespace UI {
 
 namespace UI {
 namespace Panels {
-    // Pokemon HOME-style main menu (shown when no mode is entered): a live box-preview card on the
+    // HOME-style main menu (shown when no mode is entered): a live box-preview card on the
     // left, big rounded destination pills (Pokemon / Party / Storage) + a circular icon row
     // (Items / Trainer / Settings) on the right. Replaces the old left trainer-info + mode-selector.
     void drawHomeMenu(UI::TrainerViewScreen& screen, UI::PKSEFramebuffer& fb);

--- a/include/UI/Panels/StoragePanel.h
+++ b/include/UI/Panels/StoragePanel.h
@@ -7,18 +7,20 @@ namespace UI {
 
     namespace Panels {
         /**
-         * Draws the PKSM-style dual-pane storage view: the save's PC boxes on the left and the
+         * Draws the HOME-style dual-pane storage view: the save's PC boxes on the left and the
          * persistent on-SD bank on the right. The cursor only appears once the view is entered
-         * (like Boxes) and is colored by the active CursorMode (Menu = red, Move = blue,
-         * Multi = green). Multi-selected slots are marked; a carried Pokemon rides the cursor.
+         * (like Boxes): a pointer arrow colored by the active CursorMode (Menu = red, Move = blue,
+         * Multi = green). In Multi mode a green rectangle rubber-bands out from the anchor cell,
+         * and once grabbed the whole block rides the cursor -- drawn on top of both panes so the
+         * Pokemon stay visible the entire way across the screen.
          */
         void drawStorageView(TrainerViewScreen& screen, PKSEFramebuffer& fb, int x, int y, int width, int height);
 
         /// Red-mode per-Pokemon action menu (Move / Edit / Release / Cancel).
         void drawStorageActionMenu(TrainerViewScreen& screen, PKSEFramebuffer& fb);
-        /// Green-mode group menu (Move / Release / Clear / Cancel).
+        /// Options for the block in hand (Release all / Put back / Cancel), opened with Minus.
         void drawStorageGroupMenu(TrainerViewScreen& screen, PKSEFramebuffer& fb);
-        /// Release confirmation (single Pokemon or the whole multi-selection).
+        /// Release confirmation (single Pokemon or the whole carried block).
         void drawStorageReleaseConfirm(TrainerViewScreen& screen, PKSEFramebuffer& fb);
         /// Save / Discard / Cancel prompt shown when leaving the storage view with bank changes.
         void drawStorageExitConfirm(TrainerViewScreen& screen, PKSEFramebuffer& fb);

--- a/include/UI/ScreenChrome.h
+++ b/include/UI/ScreenChrome.h
@@ -135,7 +135,7 @@ namespace UI {
     // --- Tappable badges --------------------------------------------------------------------
     //
     // Every screen already publishes a contextual hint string, so making the badges tappable gives
-    // PKSM-style on-screen action buttons everywhere at once. A tap resolves to that button's press
+    // HOME-style on-screen action buttons everywhere at once. A tap resolves to that button's press
     // and the screen ORs it into padGetButtonsDown, so no existing handler changes -- there is one
     // input path, not two, and a tap can never diverge from what the physical button does.
     //
@@ -265,7 +265,7 @@ namespace UI {
         drawNavHints(fb, 0, W, barY + kNavBarH / 2, hint);
     }
 
-    // A Pokemon HOME-style selectable list tile: rounded (stadium), soft shadow, amber when
+    // A HOME-style selectable list tile: rounded (stadium), soft shadow, amber when
     // selected. `accent` marks a special/primary row (indigo-tinted when not selected, e.g. the
     // "Create New Backup" action); `enabled` false dims it (e.g. a "no saves" placeholder).
     inline void drawHomeTile(PKSEFramebuffer& fb, int x, int y, int w, int h,

--- a/include/UI/TrainerViewScreen.h
+++ b/include/UI/TrainerViewScreen.h
@@ -32,19 +32,18 @@ namespace UI {
             Party,
             Boxes,
             Items,
-            Storage,  // PKSM-style dual-pane: save boxes (left) <-> bank (right)
+            Storage,  // HOME-style dual-pane: save boxes (left) <-> bank (right)
             Trainer,  // trainer info card (reached from the HOME main menu)
             Settings  // settings screen (auto-backup + theme)
         };
 
-        // Cursor modes for the Storage view (cycled with Y). Colors: red / blue / green.
+        // Cursor modes for the Storage view (cycled with Y). Colors: red / blue / green -- the same
+        // three-arrow scheme HOME uses, and the cursor arrow is drawn in the active mode's color.
         enum class CursorMode {
             Menu,   // red:   A opens a per-Pokemon menu (Move / Edit / Release)
-            Move,   // blue:  A directly picks up / places / swaps
-            Multi   // green: A toggles multi-selection; act on the group via the group menu
+            Move,   // blue:  A directly picks up / places / swaps one Pokemon
+            Multi   // green: A anchors a rectangle, moving expands it, A again grabs the whole block
         };
-        // A storage slot address (which pane, box, slot).
-        struct SlotRef { int pane; int box; int slot; };
         // Where the details editor's target Pokemon lives.
         enum class EditSource { Party, Box, Bank };
 
@@ -59,18 +58,30 @@ namespace UI {
         void returnHeldToOrigin();
         std::unique_ptr<Pokemon::Pokemon>& storageSlot(int pane, int box, int slot);  // pane 0=save,1=bank
         bool storageSlotLocked(int pane, int box, int slot);   // LGPE party members (save pane) are locked
-        bool prepareHeldForPane(int pane);  // convert the carried mon into the save's format if needed (Phase B)
         bool convertForPane(std::unique_ptr<Pokemon::Pokemon>& pk, int destPane);  // convert a mon in place for a dest pane (Phase B)
         void buildAbilityPickerOrder(uint16_t species, uint8_t form, uint16_t current);  // legal abilities first (green + top)
         void buildCreatorSpeciesOrder();  // creator: filter the species picker to the open game's dex
         void buildMovePickerOrder(uint16_t species, uint8_t form, Enums::GameVersion group, uint16_t current);  // learnable moves first
         void openStorageEditor(int pane, int box, int slot);   // open the details modal on a storage slot
-        void transferSelectionToOtherPane();                   // green group menu: bulk move the selection to the other pane
-        void moveSelectionTo(int destPane, int destBox, int destSlot);  // green: drop the selection starting at a slot
+
+        // --- HOME-style rectangle select + block carry (see moveMon below) ---
+        int paneCols(int pane) const;      // grid columns (LGPE save boxes are 5 wide, everything else 6)
+        int paneSlots(int pane) const;     // slots per box in that pane
+        int paneBoxes(int pane) const;     // box count in that pane
+        void storagePickup();          // the A press: anchor / grab / put down, whichever applies
+        void pickupSingle();           // Move mode: lift the slot under the cursor as a 1x1 block
+        void pickupMulti();            // Multi mode: anchor the rectangle, or grab it if already anchoring
+        void grabSelection(bool remove);   // lift (or copy, when !remove) the anchored rectangle into moveMon
+        void scrunchSelection();       // trim all-empty edge rows/columns off the grabbed block
+        void postPickup();             // drop an all-empty block so the hands read as free
+        bool checkPutDownBounds() const;   // does the block fit in the focused pane from the cursor cell?
+        void putDownBlock();           // exact-slot placement: cell (x,y) -> cursor slot + x + y*cols
+        void cancelSelection();        // abandon an in-progress rectangle
+
         bool lgpeConversionInvolved(int destPane, const Pokemon::Pokemon* pk) const;  // would placing pk into destPane run an LGPE (AV/EV-reset) conversion?
-        bool selectionInvolvesLgpe(int destPane) const;        // does any multi-selected mon trigger an LGPE conversion into destPane?
+        bool blockInvolvesLgpe(int destPane) const;            // does any carried mon trigger an LGPE conversion into destPane?
         bool gen3DowngradeInvolved(int destPane, const Pokemon::Pokemon* pk) const;  // would placing pk into destPane convert it DOWN into Gen 3 (destructive PID rebuild)?
-        bool selectionInvolvesGen3Downgrade(int destPane) const;  // does any multi-selected mon trigger a Gen 3 downgrade into destPane?
+        bool blockInvolvesGen3Downgrade(int destPane) const;    // does any carried mon trigger a Gen 3 downgrade into destPane?
         Pokemon::Pokemon* detailsTargetPokemon();              // resolve the editor's current target (party/box/bank)
         void mirrorEditedPartyMember();                        // after an edit, keep an LGPE party member's box/party copies in sync
         void snapshotEditTarget();     // capture the target's bytes as the save baseline (modal open + X = Save); revert restores to it
@@ -109,10 +120,6 @@ namespace UI {
         // 3 Items, 4 Trainer, 5 Settings (circular icons). Replaces the old left mode-selector.
         int homeMenuIndex = 0;
 
-        // Box cursor scale-pop (Phase 4.6): the selected disc briefly pops when the cursor moves.
-        int animPrevBoxSlot = -1;
-        double animBoxPopStart = -100.0;
-
         // Selected row in the Settings view (0-4); reached from the menu's Settings icon.
         int settingsSelectedRow = 0;
 
@@ -144,7 +151,7 @@ namespace UI {
         // appears after the dialog closes). Consumed at the top of the next update().
         bool pendingHeaderRename = false;
 
-        // --- PKSM-style Storage view: dual-pane save boxes <-> bank ---
+        // --- HOME-style Storage view: dual-pane save boxes <-> bank ---
         std::unique_ptr<Trainer::Bank> bank;        // created in the ctor
         CursorMode cursorMode = CursorMode::Menu;   // default red (menu); cycled with Y
         int storageFocusPane = 0;                   // 0 = save (left), 1 = bank (right)
@@ -159,22 +166,39 @@ namespace UI {
             storageStatus = msg;
             storageStatusFrames = frames;
         }
-        // Carried single Pokemon (Move-mode pick-up, or the red menu's "Move").
-        std::unique_ptr<Pokemon::Pokemon> heldPokemon;
-        int heldPane = 0, heldFromBox = 0, heldFromSlot = 0;   // origin (for cancel/return)
+        // --- The carried block ---
+        // Cells of the rectangle currently in hand, row-major over selectDimensions (w x h). A null
+        // cell is a hole -- the source slot was empty, or it was locked and deliberately left behind.
+        // An empty vector means hands free.
+        //
+        // A Move-mode pick-up is just a 1x1 block, so this is the ONLY carry state: there is no
+        // separate "held single Pokemon" to keep in sync, and every guard that asks "are we holding
+        // something?" (compaction, sort, exit, box rename) answers for both cases at once.
+        std::vector<std::unique_ptr<Pokemon::Pokemon>> moveMon;
+        // Two meanings:
+        //   while currentlySelecting -> the anchor cell as (column, row) of the rectangle being drawn
+        //   while carrying           -> the block's dimensions as (width, height)
+        std::pair<int, int> selectDimensions{0, 0};
+        bool currentlySelecting = false;         // Multi mode: a rectangle is being dragged out
+        int selectPane = 0, selectBox = 0;       // which pane/box the in-progress rectangle lives in
+        // Origin of the block's TOP-LEFT cell, so B can put the whole thing back where it came from.
+        int heldPane = 0, heldFromBox = 0, heldFromSlot = 0;
+        bool carrying() const { return !moveMon.empty(); }
+        int carriedCount() const;                // non-null cells in moveMon
+        const Pokemon::Pokemon* firstCarried() const;   // first non-null cell, or nullptr
+
         // Red per-Pokemon action menu (Move / Edit / Release / Cancel).
         bool storageMenuActive = false;
         int storageMenuIndex = 0;
         int menuPane = 0, menuBox = 0, menuSlot = 0;           // the slot the menu acts on
-        // Green multi-selection + its group menu (Move / Release / Clear / Cancel).
-        std::vector<SlotRef> multiSel;
+        // Group menu for the carried block (Release all / Return to origin / Cancel), opened with Minus.
         bool groupMenuActive = false;
         int groupMenuIndex = 0;
-        // Release confirmation (single slot, or the whole multi-selection when releaseGroup).
+        // Release confirmation (single slot, or the whole carried block when releaseGroup).
         bool releaseConfirmActive = false;
         int releasePane = 0, releaseBox = 0, releaseSlot = 0;
         bool releaseGroup = false;
-        // Leaving the storage view with unsaved bank changes: prompt Save / Discard / Cancel (PKSM-style).
+        // Leaving the storage view with unsaved bank changes: prompt Save / Discard / Cancel (HOME-style).
         bool storageExitConfirmActive = false;
         int storageExitConfirmIndex = 0;   // 0=Save & Exit, 1=Discard & Exit, 2=Cancel
         // Set when + (exit app) raised that prompt instead of B. Closing the app is not an answer to
@@ -202,7 +226,7 @@ namespace UI {
 
         // Save confirmation state
         bool saveConfirmActive = false;
-        // Save destination picker, on PKSM's model.
+        // Save destination picker.
         //   0 = this backup   1 = new named backup   2 = game save
         //
         // Whether "game save" is offered depends on WHERE THIS SESSION CAME FROM, not on a blanket
@@ -282,7 +306,7 @@ namespace UI {
         CreatorState creator;
         // Let's Go move acknowledgement (settings-gated by g_lgpeMoveWarn): moving a mon to/from LGPE
         // resets AVs/EVs, so the user confirms first. The pending storage action is stashed + run on Yes.
-        enum class LgpePending { None, PlaceHeld, GroupMoveTo, GroupTransfer };
+        enum class LgpePending { None, PlaceHeld };
         bool lgpeMoveConfirmActive = false;
         int  lgpeMoveConfirmIndex = 1;          // cursor: 0 = Cancel, 1 = Continue (default)
         LgpePending lgpePending = LgpePending::None;

--- a/src/Conversion/Convert.cpp
+++ b/src/Conversion/Convert.cpp
@@ -541,7 +541,7 @@ namespace Conversion {
             wr8(d, 0x125, static_cast<uint8_t>((origins & 0x7F) | (((origins >> 15) & 1) << 7)));    // MetLevel + OTgender
             wr16(d, 0x122, rd8(s, 0x45));                           // Met location (Gen 3 id -- carried)
             // Gen 3 records no met DATE, so leaving it 0 reads as "met 00/00/2000" in the destination.
-            // Emulate Pokemon HOME: PKHeX's PK3.ConvertToPK4() stamps MetDate = EncounterDate.GetDateNDS()
+            // Emulate HOME: PKHeX's PK3.ConvertToPK4() stamps MetDate = EncounterDate.GetDateNDS()
             // (the transfer date). Do the same with today's date; it rides the PK8-hub met-date region
             // (0x11C-0x11E, year stored as year-2000) out to every destination format. Skip an egg -- an
             // unhatched egg has no met date until it hatches (isEgg is iv32 bit 30, carried above).
@@ -570,7 +570,7 @@ namespace Conversion {
 
             // Gen 3 derives nature/gender/shiny/ability ALL from the PID, but the source stores nature
             // and gender EXPLICITLY -- copying the PID verbatim silently changes them (an LGPE Calm mon
-            // read as Jolly in FR/LG). Like PKSM's downgrade (PKX::getRandomPID), reroll the PID so its
+            // read as Jolly in FR/LG). The standard down-convert answer is to reroll the PID so its
             // Gen-3-derived traits match the source's: nature, gender, shiny status and ability slot are
             // preserved. IVs are NOT touched (separate field at 0x48). This DOES change the PID (the mon's
             // identity) and yields a PID/IV pair that won't match a real Gen 3 RNG frame -- the UI warns

--- a/src/Encryption/Encryption3FRLG.cpp
+++ b/src/Encryption/Encryption3FRLG.cpp
@@ -2,7 +2,7 @@
  * Encryption3FRLG.cpp - Gen 3 (GBA / FRLG) PK3 decrypt/encrypt. See Encryption3FRLG.h.
  *
  * Tables + algorithm verified against PKHeX PokeCrypto.cs (BlockPosition / BlockPositionInvert,
- * CryptArray3) and PKSM crypto.hpp. The 0x20-0x4F block is XORed per 32-bit word with (PID ^ OT_ID32)
+ * CryptArray3). The 0x20-0x4F block is XORed per 32-bit word with (PID ^ OT_ID32)
  * and the four 12-byte substructures are shuffled by (PID % 24).
  */
 #include "Encryption/Encryption3FRLG.h"

--- a/src/UI/Modals/PokemonDetailsModal.cpp
+++ b/src/UI/Modals/PokemonDetailsModal.cpp
@@ -33,7 +33,7 @@ using namespace Utils;
 namespace UI {
 namespace Modals {
 
-    // Pokemon HOME "Check Summary"-style editor page. Full-screen, three columns: the render + details
+    // HOME "Check Summary"-style editor page. Full-screen, three columns: the render + details
     // (left), the editable stat table + shiny/nature/gender (center — the navigable "Values" column),
     // and the moveset editor (right — moves + held item). Editing is handled in TrainerViewScreen; this
     // only draws + captures touch.

--- a/src/UI/PKSEFramebuffer.cpp
+++ b/src/UI/PKSEFramebuffer.cpp
@@ -220,7 +220,7 @@ namespace UI {
     }
 
     void PKSEFramebuffer::drawShinyMark(int x, int y, int size, Color color) {
-        // Pokemon HOME's shiny mark: a four-pointed sparkle. The four tips sit on the cardinal
+        // HOME's shiny mark: a four-pointed sparkle. The four tips sit on the cardinal
         // directions; the edges between them curve INWARD (a quad curve pulled toward a control
         // point near the center), so it reads as a pinched "twinkle" rather than a plain star.
         // Anchored top-left in a size×size box to match how drawSymbol placed the old ★ glyph.
@@ -237,6 +237,88 @@ namespace UI {
         nvgQuadTo(vg, cx - ck, cy - ck, cx,     cy - R);       // -> back to top tip
         nvgClosePath(vg);
         nvgFillColor(vg, toNVG(color)); nvgFill(vg);
+    }
+
+    void PKSEFramebuffer::drawPointerCursor(int tipX, int tipY, int headHeight, Color color) {
+        // The storage grid's cursor: a slim arrowhead, pointing straight down at the slot, with no
+        // shaft. Four corners, in art units 18 wide by 26 tall with the point at (0, 0).
+        //
+        // This is drawn rather than copied. Tracing an existing 3DS-era pointer sprite was tried first
+        // and abandoned: it is 19x28 pixels, so at the size PKSE needs it every wobble in
+        // the original outline shows. The proportions below were instead chosen against a real 78px
+        // slot disc at the sizes the app actually uses.
+        //
+        // Two of them matter more than they look:
+        //   * The notch depth is tied to the width. Arm thickness is w*n/hypot(w,26), so a narrow
+        //     head with a deep notch thins the arms until the outline is most of what is left and
+        //     the colour barely shows -- hence the shallower -20 that goes with these narrow wings.
+        //   * The corners are mitred. Rounding them swallows the notch and the point, and what
+        //     survives reads as a circle.
+        // The body is bevelled rather than flat-filled, which is what stops a solid silhouette from
+        // reading as a flat cut-out.
+        static const signed char kArrow[][2] = {
+            {  0,   0},   // the point
+            { -9, -26},   // left wing
+            {  0, -20},   // the notch in the back edge
+            {  9, -26},   // right wing
+        };
+        constexpr int n = (int)(sizeof(kArrow) / sizeof(kArrow[0]));
+        if (headHeight <= 6 || !ensureFrame()) return;
+
+        // The outline is drawn UNDER the body, not over it. Strokes are centred on the path, so at a
+        // ~60-degree apex they cover the fill for several pixels and the point reads as a hollow V.
+        // Stroking wide first and filling on top leaves the outline entirely outside the body, and
+        // the body itself runs all the way into the point.
+        //
+        // `headHeight` is the head itself -- the part you actually see as the arrow. Below it the
+        // mitred outline runs on to a point, overshooting the apex by outer/sin(halfAngle). That is
+        // measured off the art rather than hardcoded, because it depends strongly on how slim the
+        // head is (2.0x the outline thickness at the widest head tried, 3.1x at this one); pin it to
+        // a constant and a reshape silently pokes the point lower than the caller reserved room for.
+        float halfW = 1.0f, artH = 1.0f;
+        for (int i = 0; i < n; ++i) {
+            halfW = std::max(halfW, (float)std::abs(kArrow[i][0]));
+            artH  = std::max(artH,  (float)-kArrow[i][1]);
+        }
+        // outer is 7% of the WHOLE cursor, and the whole cursor is head + over -- so solve for over
+        // rather than measuring it off a total we do not have yet.
+        const float f     = 0.07f * std::sqrt(halfW * halfW + artH * artH) / halfW;
+        const float over  = headHeight * f / (1.0f - f);
+        const float outer = (headHeight + over) * 0.07f;   // outline thickness outside the body
+        const float s = headHeight / artH;
+        const float baseY = tipY - over;         // the body's apex; the outline's point is at tipY
+        auto trace = [&](float dx, float dy) {
+            nvgBeginPath(vg);
+            for (int i = 0; i < n; ++i) {
+                const float X = tipX + dx + kArrow[i][0] * s;
+                const float Y = baseY + dy + kArrow[i][1] * s;
+                if (i == 0) nvgMoveTo(vg, X, Y); else nvgLineTo(vg, X, Y);
+            }
+            nvgClosePath(vg);
+        };
+        auto shade = [&](float f) {   // f < 1 darkens, f > 1 lightens toward white
+            auto ch = [&](int v) {
+                const float o = (f <= 1.0f) ? v * f : v + (255.0f - v) * (f - 1.0f);
+                return (unsigned char)std::min(255.0f, std::max(0.0f, o));
+            };
+            return nvgRGBA(ch(color.r), ch(color.g), ch(color.b), color.a);
+        };
+
+        // Drop shadow: the whole outer silhouette (stroke + fill), offset.
+        trace(headHeight * 0.04f, headHeight * 0.07f);
+        nvgFillColor(vg, nvgRGBA(0, 0, 0, 105));
+        nvgStrokeColor(vg, nvgRGBA(0, 0, 0, 105)); nvgStrokeWidth(vg, outer * 2.0f);
+        nvgStroke(vg); nvgFill(vg);
+
+        // Widest stroke first, then a narrower dark one over its inner half, then the body over
+        // that: what is left outside the body is a dark rim with a white outline beyond it.
+        trace(0.0f, 0.0f);
+        nvgStrokeColor(vg, nvgRGBA(242, 242, 242, 240)); nvgStrokeWidth(vg, outer * 2.0f);   nvgStroke(vg);
+        nvgStrokeColor(vg, shade(0.42f));                nvgStrokeWidth(vg, outer * 0.9f);   nvgStroke(vg);
+        // Lit from the upper-left, falling off across the head.
+        NVGpaint body = nvgLinearGradient(vg, tipX - halfW * s, baseY - artH * s, tipX + halfW * s, baseY,
+                                          shade(1.5f), toNVG(color));
+        nvgFillPaint(vg, body); nvgFill(vg);
     }
 
     void PKSEFramebuffer::drawPill(int x, int y, int w, int h, Color color) {
@@ -446,27 +528,6 @@ namespace UI {
         Color txt = lum > 150 ? Color(30, 30, 36) : Color(245, 245, 250);
         drawText(x + padX, y + (h - th) / 2, typeName, txt, TextStyle::Caption);
         return total;
-    }
-
-    void PKSEFramebuffer::drawNameCursorLabel(int cx, int topY, const std::string& text,
-                                              Color fill, Color textColor) {
-        int tw, th; measureText(text, tw, th, TextStyle::Caption);
-        const int padX = 12, padY = 6, tri = 7;
-        const int w = tw + padX * 2, h = th + padY * 2;
-        int x = cx - w / 2, y = topY - tri - h;
-        drawSoftShadow(x, y, w, h, 8);
-        drawFilledRoundedRect(x, y, w, h, 8, fill);
-        drawText(x + padX, y + padY, text, textColor, TextStyle::Caption);
-        // Downward triangle tail.
-        if (ensureFrame()) {
-            int ty = y + h;
-            nvgBeginPath(vg);
-            nvgMoveTo(vg, (float)(cx - tri), (float)ty);
-            nvgLineTo(vg, (float)(cx + tri), (float)ty);
-            nvgLineTo(vg, (float)cx, (float)(ty + tri));
-            nvgClosePath(vg);
-            nvgFillColor(vg, toNVG(fill)); nvgFill(vg);
-        }
     }
 
     // ---- Screen fade ----

--- a/src/UI/Panels/BoxPokemonPanel.cpp
+++ b/src/UI/Panels/BoxPokemonPanel.cpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "UI/Panels/BoxPokemonPanel.h"
+#include "UI/Panels/CarriedSprite.h"   // drawLiftedMon -- shared with the bank
 #include "UI/TrainerViewScreen.h"
 #include "UI/Common.h"
 #include "UI/PKSEFramebuffer.h"
@@ -30,7 +31,7 @@ namespace Panels {
         return w;
     }
 
-    // Pokemon HOME-style box: rounded card, indigo header with a centered name pill and ‹ ›
+    // HOME-style box: rounded card, indigo header with a centered name pill and ‹ ›
     // arrows, a grid of sprite-on-disc cells, a floating name-cursor on the selection, and a
     // slim selected-info strip at the bottom.
     void drawBoxPokemon(TrainerViewScreen& screen, PKSEFramebuffer& fb, int x, int y, int width, int height) {
@@ -98,19 +99,23 @@ namespace Panels {
         int discR = std::min(colPitch, rowPitch) / 2 - 6;
         if (discR < 18) discR = 18;
 
-        int selCx = 0, selTopY = 0;            // where to hang the name-cursor (drawn last, on top)
-        std::string selLabel;
+        // The cursor and anything riding it are drawn last, over the finished grid.
+        int selCx = 0, selDiscTop = 0, selDiscR = discR;
         bool haveSel = false;
 
-        // Cursor scale-pop (Phase 4.6): restart the pop timer when the selection changes; the
-        // selected disc briefly scales up (~16%) then settles over 0.14s.
-        const double nowT = fb.getTimeSeconds();
-        if (screen.detailViewActive && screen.selectedItemIndex != screen.animPrevBoxSlot) {
-            screen.animBoxPopStart = nowT;
-            screen.animPrevBoxSlot = screen.selectedItemIndex;
+        // Y grabs the slot under the cursor and a second Y drops it. The grabbed Pokemon is not
+        // actually moved out of its slot until then (see the Y handler), but it READS as picked up:
+        // its slot is drawn empty and the Pokemon itself travels with the cursor, exactly as a
+        // carried one does in the bank. Sourced from the grabbed slot rather than the visible box,
+        // so it keeps following the cursor after changing box with L/R.
+        const ::Pokemon::Pokemon* carried = nullptr;
+        if (screen.swapActive &&
+            screen.swapSourceBox >= 0 && screen.swapSourceBox < static_cast<int>(screen.trainer.boxes.size()) &&
+            screen.swapSourceSlot >= 0 && screen.swapSourceSlot < slotsPerBox) {
+            carried = screen.trainer.boxes[screen.swapSourceBox][screen.swapSourceSlot].get();
         }
-        const double popRaw = 1.0 - (nowT - screen.animBoxPopStart) / 0.14;
-        const double pop = popRaw > 0.0 ? popRaw : 0.0;
+
+        const double nowT = fb.getTimeSeconds();   // drives the cursor's bob
 
         for (int row = 0; row < GRID_ROWS; ++row) {
             for (int col = 0; col < GRID_COLS; ++col) {
@@ -127,25 +132,22 @@ namespace Panels {
                 const bool grabbed  = screen.swapActive &&
                                       screen.swapSourceBox == screen.selectedBoxIndex &&
                                       screen.swapSourceSlot == slotIndex;
-                // Selected disc pops (scales up ~16%) briefly when the cursor lands on it.
-                const int r = selected ? discR + static_cast<int>(std::lround(discR * 0.16 * pop)) : discR;
 
                 const auto& pokemon = currentBox[slotIndex];
                 std::string speciesName = pokemon ? std::string(pokemon->species()) : "";
-                const bool empty = !pokemon || speciesName == "None" || speciesName == "Empty" ||
+                // A grabbed slot renders empty: its occupant is drawn riding the cursor instead, so
+                // showing it here too would put the same Pokemon on screen twice.
+                const bool empty = grabbed || !pokemon || speciesName == "None" || speciesName == "Empty" ||
                                    pokemon->speciesID() == 0;
 
-                // Selection halo (soft glow behind the disc).
-                if (selected) fb.drawFilledCircle(cx, cy, r + 5, Color(Colors::Accent.r, Colors::Accent.g, Colors::Accent.b, 70));
-
                 // Disc: occupied a touch lighter than empty for subtle depth.
-                fb.drawFilledCircle(cx, cy, r, empty ? Colors::Panel : Colors::PanelAlt);
+                fb.drawFilledCircle(cx, cy, discR, empty ? Colors::Panel : Colors::PanelAlt);
 
                 if (empty) {
-                    fb.drawCircle(cx, cy, r, Colors::Border, 1);
+                    fb.drawCircle(cx, cy, discR, Colors::Border, 1);
                 } else {
                     const bool isShiny = pokemon->isShiny(pokemon->id32(), speciesName);
-                    int sz = std::min(static_cast<int>(r * 1.8), colPitch - 6);
+                    int sz = std::min(static_cast<int>(discR * 1.8), colPitch - 6);
                     if (pokemon->isEgg()) {
                         // Eggs show as an egg in the grid; the summary panel still shows the species.
                         fb.drawEgg(cx, cy, sz);
@@ -158,43 +160,42 @@ namespace Panels {
                     }
                     // Markers: partner heart (top-left), party number (bottom-left), shiny star (top-right).
                     if (screen.trainer.isStarterPokemon(screen.selectedBoxIndex, slotIndex))
-                        fb.drawSymbol(cx - r, cy - r + 2, "♥", Colors::PartnerHeart);
+                        fb.drawSymbol(cx - discR, cy - discR + 2, "♥", Colors::PartnerHeart);
                     int partyPos = screen.trainer.getPartyPosition(screen.selectedBoxIndex, slotIndex);
                     if (partyPos > 0) {
                         // Gold badge + dark digit (bottom-left), legible on any sprite in either theme.
                         const std::string n = std::to_string(partyPos);
-                        const int bx = cx - r + 9, by = cy + r - 9;
+                        const int bx = cx - discR + 9, by = cy + discR - 9;
                         fb.drawFilledCircle(bx, by, 9, Colors::PartyBadge);
                         int tw, th; fb.measureText(n, tw, th, TextStyle::Caption);
                         fb.drawText(bx - tw / 2, by - th / 2, n, Colors::PartyBadgeText, TextStyle::Caption);
                     }
                     if (isShiny)
-                        fb.drawShinyMark(cx + r - 15, cy - r + 1, 15, Colors::ShinyStar);
-
-                    if (selected) {
-                        selCx = cx; selTopY = cy - r - 2; haveSel = true;
-                        selLabel = Names::getDisplayName(pokemon->speciesID(), pokemon->form(), speciesName)
-                                 + " (Lv. " + std::to_string(pokemon->level()) + ")";
-                    }
+                        fb.drawShinyMark(cx + discR - 15, cy - discR + 1, 15, Colors::ShinyStar);
                 }
 
-                // Selection / grab ring on top of the disc.
-                if (grabbed)       fb.drawCircle(cx, cy, r + 2, Colors::Primary, 3);
-                else if (selected) fb.drawCircle(cx, cy, r + 2, Colors::Accent, 3);
+                if (selected) { selCx = cx; selDiscTop = cy - discR; selDiscR = discR; haveSel = true; }
             }
         }
 
-        // Card border, then the floating HOME name-cursor over the selected disc (drawn last = on top).
         fb.drawRoundedRect(x, y, width, height, 16, Colors::Border, 1);
+
+        // Cursor last, over the finished grid: the same arrow the bank uses, in this view's own
+        // colours -- indigo while browsing, amber while carrying, matching the rings it replaces.
+        // Anything in hand rides it, drawn first so the arrow stays on top.
+        const Color cur = screen.swapActive ? Colors::Primary : Colors::Accent;
+        const int bob = static_cast<int>(std::sin(nowT * 3.4) * 3.0);
         if (haveSel) {
-            // Theme-aware chip: indigo accent in light mode, near-black in dark mode; always light
-            // text so it stays readable (a fixed dark chip + Colors::Text went invisible in light mode).
-            const Color cursorFill = (g_themeMode == ThemeMode::Light) ? Colors::Accent : Color(24, 23, 32, 240);
-            fb.drawNameCursorLabel(selCx, selTopY, selLabel, cursorFill, Colors::White);
+            if (carried) drawLiftedMon(fb, carried, selCx, selDiscTop + selDiscR + bob, selDiscR);
+            fb.drawPointerCursor(selCx, selDiscTop - 3 + bob, kGridCursorH, cur);
+        } else if (headerFocused) {
+            // The box-name pill is a cursor position of its own; point at it too, so navigating up
+            // off the top row never leaves the cursor invisible.
+            fb.drawPointerCursor(x + width / 2, pillY - 2 + bob, kGridCursorH, cur);
         }
     }
 
-    // Pokemon HOME-style summary side-panel (shown right of the box when entered): big idle HD
+    // HOME-style summary side-panel (shown right of the box when entered): big idle HD
     // render, name/level/gender/shiny, type icons, the stat hexagon (actual stats), and a
     // Nature/Ability/Held Item card. Tapping it (id 2000) opens the full editor. Read-only display.
     void drawBoxSummaryPanel(TrainerViewScreen& screen, PKSEFramebuffer& fb, int x, int y, int width, int height) {

--- a/src/UI/Panels/StoragePanel.cpp
+++ b/src/UI/Panels/StoragePanel.cpp
@@ -1,9 +1,11 @@
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <memory>
 #include <string>
 
 #include "UI/Panels/StoragePanel.h"
+#include "UI/Panels/CarriedSprite.h"   // drawLiftedMon -- shared with the Boxes view
 #include "UI/TrainerViewScreen.h"
 #include "UI/Common.h"
 #include "UI/PKSEFramebuffer.h"
@@ -21,17 +23,12 @@ namespace UI {
 namespace Panels {
 
     namespace {
-        // Cursor-mode colors: red (Menu), blue (Move), green (Multi).
-        constexpr Color MenuColor(232, 92, 92);
-        constexpr Color MoveColor(86, 148, 244);
-        constexpr Color MultiColor(96, 205, 128);
-
         Color cursorColorFor(TrainerViewScreen::CursorMode mode) {
             switch (mode) {
-                case TrainerViewScreen::CursorMode::Move:  return MoveColor;
-                case TrainerViewScreen::CursorMode::Multi: return MultiColor;
+                case TrainerViewScreen::CursorMode::Move:  return Colors::CursorMove;
+                case TrainerViewScreen::CursorMode::Multi: return Colors::CursorMulti;
                 case TrainerViewScreen::CursorMode::Menu:
-                default:                                   return MenuColor;
+                default:                                   return Colors::CursorMenu;
             }
         }
 
@@ -43,6 +40,18 @@ namespace Panels {
                 default:                                   return "MENU";
             }
         }
+
+        // Cell geometry of a drawn pane, handed back so the carried block and the cursor can be
+        // drawn AFTER both panes (otherwise the second pane's card paints over a block being
+        // carried across the boundary).
+        struct PaneGeom {
+            int gridX = 0, gridTop = 0, colPitch = 0, rowPitch = 0, discR = 0, cols = 1, rows = 5;
+            int pillCx = 0, pillTop = 0;   // box-name pill, so the cursor can point at it too
+            int cellX(int slot) const { return gridX + (slot % cols) * colPitch; }
+            int cellY(int slot) const { return gridTop + (slot / cols) * rowPitch; }
+            int centerX(int slot) const { return cellX(slot) + colPitch / 2; }
+            int centerY(int slot) const { return cellY(slot) + rowPitch / 2; }
+        };
 
         // Draw one Pokemon (sprite + shiny/party markers) centered on a slot disc of radius discR.
         void drawSlotDisc(TrainerViewScreen& screen, PKSEFramebuffer& fb,
@@ -83,12 +92,12 @@ namespace Panels {
         }
 
         // Draws one storage pane in the HOME box style (rounded card + indigo header band + disc
-        // grid). Reports the cursor disc's pixel rect via outCursorRect (to lift a carried Pokemon).
+        // grid), and reports its cell geometry via outGeom.
         void drawPane(TrainerViewScreen& screen, PKSEFramebuffer& fb,
                      int px, int py, int pw, int ph, bool savePane,
                      int boxIndex, int cursorSlot, bool focused, bool entered,
                      int cols, int rows, int slotsPerBox,
-                     const std::string& label, int boxCount, int outCursorRect[4]) {
+                     const std::string& label, int boxCount, PaneGeom& outGeom) {
             fb.drawFilledRoundedRect(px, py, pw, ph, 16, Colors::Panel);
 
             // Header band (rounded top). Focused pane = accent indigo; unfocused = dim.
@@ -107,8 +116,8 @@ namespace Panels {
             fb.drawText(px + (pw - lw) / 2, pillY + (pillH - lh) / 2, label, headerFocused ? Colors::PrimaryText : Colors::Text);
 
             const int arrowY = py + (headerH - lh) / 2;
-            fb.drawSymbol(px + 18, arrowY, "\xE2\x97\x80", focused ? Colors::Text : Colors::TextDim);        // ◀
-            fb.drawSymbol(px + pw - 32, arrowY, "\xE2\x96\xB6", focused ? Colors::Text : Colors::TextDim);   // ▶
+            fb.drawSymbol(px + 18, arrowY, "\xE2\x97\x80", focused ? Colors::Text : Colors::TextDim);        // left
+            fb.drawSymbol(px + pw - 32, arrowY, "\xE2\x96\xB6", focused ? Colors::Text : Colors::TextDim);   // right
             // Tappable box arrows (special slot ids -2 = prev box, -3 = next box) and the name pill
             // (-4 = rename this box). The name target sits between the two arrow zones.
             screen.storageTouchTargets.push_back({ savePane ? 0 : 1, boxIndex, -2, px, py, 64, headerH });
@@ -123,22 +132,31 @@ namespace Panels {
             const int colPitch = gridW / cols, rowPitch = gridH / rows;
             int discR = std::min(colPitch, rowPitch) / 2 - 4;
             if (discR < 12) discR = 12;
+            outGeom = PaneGeom{gridX, gridTop, colPitch, rowPitch, discR, cols, rows,
+                               px + pw / 2, pillY};
 
             const int thisPane = savePane ? 0 : 1;
-            auto isMultiSel = [&](int i) {
-                for (const auto& s : screen.multiSel)
-                    if (s.pane == thisPane && s.box == boxIndex && s.slot == i) return true;
-                return false;
-            };
-            const Color cur = cursorColorFor(screen.cursorMode);
+
+            // The rubber-band rectangle being swept out in Multi mode: a green wash UNDER the
+            // Pokemon (so they stay readable) with a matching border on top. It spans from the
+            // anchor cell to the cell under the cursor, the way HOME's multi-select highlight does.
+            int selC0 = -1, selR0 = -1, selC1 = -1, selR1 = -1;
+            if (screen.currentlySelecting && entered && screen.selectPane == thisPane &&
+                screen.selectBox == boxIndex && cursorSlot >= 0) {
+                const int ax = screen.selectDimensions.first, ay = screen.selectDimensions.second;
+                const int cxs = cursorSlot % cols, cys = cursorSlot / cols;
+                selC0 = std::min(ax, cxs); selC1 = std::max(ax, cxs);
+                selR0 = std::min(ay, cys); selR1 = std::max(ay, cys);
+                const Color wash(Colors::CursorMulti.r, Colors::CursorMulti.g, Colors::CursorMulti.b, 64);
+                fb.drawFilledRoundedRect(gridX + selC0 * colPitch + 2, gridTop + selR0 * rowPitch + 2,
+                                         (selC1 - selC0 + 1) * colPitch - 4, (selR1 - selR0 + 1) * rowPitch - 4,
+                                         14, wash);
+            }
 
             for (int i = 0; i < slotsPerBox; ++i) {
                 const int row = i / cols, col = i % cols;
                 const int cellX = gridX + col * colPitch, cellY = gridTop + row * rowPitch;
                 const int cx = cellX + colPitch / 2, cy = cellY + rowPitch / 2;
-
-                const bool isCursor = focused && entered && i == cursorSlot;
-                const bool selected = isMultiSel(i);
 
                 // Whole-cell touch target (consumed next frame in update()).
                 screen.storageTouchTargets.push_back({thisPane, boxIndex, i, cellX, cellY, colPitch, rowPitch});
@@ -147,19 +165,71 @@ namespace Panels {
                                                       : (screen.bank ? screen.bank->boxes[boxIndex][i].get() : nullptr);
                 const bool empty = !pk || pk->speciesID() == 0;
 
-                if (isCursor) fb.drawFilledCircle(cx, cy, discR + 5, Color(cur.r, cur.g, cur.b, 70));  // mode-color halo
                 fb.drawFilledCircle(cx, cy, discR, empty ? Colors::Panel : Colors::PanelAlt);
                 if (empty) fb.drawCircle(cx, cy, discR, Colors::Border, 1);
 
                 drawSlotDisc(screen, fb, pk, savePane, boxIndex, i, cx, cy, discR);
-
-                if (selected) fb.drawCircle(cx, cy, discR + 2, MultiColor, 3);      // green multi-select ring
-                if (isCursor) {
-                    fb.drawCircle(cx, cy, discR + 2, cur, 3);                        // mode-color cursor ring
-                    outCursorRect[0] = cx - discR; outCursorRect[1] = cy - discR;
-                    outCursorRect[2] = 2 * discR;  outCursorRect[3] = 2 * discR;
-                }
             }
+
+            if (selC0 >= 0) {
+                fb.drawRoundedRect(gridX + selC0 * colPitch + 2, gridTop + selR0 * rowPitch + 2,
+                                   (selC1 - selC0 + 1) * colPitch - 4, (selR1 - selR0 + 1) * rowPitch - 4,
+                                   14, Colors::CursorMulti, 3);
+            }
+        }
+
+        // The carried block plus the pointer cursor, drawn on top of BOTH panes so a group stays
+        // fully visible while it travels across the screen and over the pane boundary.
+        void drawCarryAndCursor(TrainerViewScreen& screen, PKSEFramebuffer& fb, const PaneGeom& g, int cursorSlot) {
+            const Color cur = cursorColorFor(screen.cursorMode);
+            // Gentle vertical bob, a HOME-style pointer wobble done as a sine so it is framerate-independent.
+            const int bob = static_cast<int>(std::sin(fb.getTimeSeconds() * 3.4) * 3.0);
+            // The head is symmetric about its point, so the point goes straight on the slot's
+            // centre line -- no horizontal nudge needed.
+
+            // The box-name pill is a cursor position of its own (slot -1): navigate up off the top
+            // row onto it and A renames the box. Point at it with the same arrow so the cursor is
+            // never invisible, rather than relying on the pill's amber highlight alone.
+            if (cursorSlot < 0) {
+                fb.drawPointerCursor(g.pillCx, g.pillTop - 2 + bob, kGridCursorH, cur);
+                return;                                  // the header is unreachable while carrying
+            }
+
+            if (screen.carrying()) {
+                const int w = std::max(1, screen.selectDimensions.first);
+                const int h = std::max(1, screen.selectDimensions.second);
+                const bool fits = screen.checkPutDownBounds();
+                // A group that would hang off the grid is tinted with the warning colour, so the
+                // "must land in the exact slots" rule is visible before you press A rather than after.
+                const Color tint = fits ? cur : Colors::Warning;
+                const int baseX = g.cellX(cursorSlot), baseY = g.cellY(cursorSlot);
+                for (int y = 0; y < h; ++y) {
+                    for (int x = 0; x < w; ++x) {
+                        const size_t idx = static_cast<size_t>(y) * static_cast<size_t>(w) + static_cast<size_t>(x);
+                        if (idx >= screen.moveMon.size()) continue;
+                        const int cx = baseX + x * g.colPitch + g.colPitch / 2;
+                        const int cy = baseY + y * g.rowPitch + g.rowPitch / 2 + bob;
+                        // Backing tile marks the footprint the block will occupy -- including its
+                        // holes, which stay empty when it lands.
+                        if (w > 1 || h > 1)
+                            fb.drawFilledRoundedRect(cx - g.colPitch / 2 + 3, cy - g.rowPitch / 2 + 3,
+                                                     g.colPitch - 6, g.rowPitch - 6, 14,
+                                                     Color(tint.r, tint.g, tint.b, 70));
+                        drawLiftedMon(fb, screen.moveMon[idx].get(), cx, cy, g.discR);
+                    }
+                }
+                if (w > 1 || h > 1)
+                    fb.drawRoundedRect(baseX + 3, baseY + 3 + bob, w * g.colPitch - 6, h * g.rowPitch - 6,
+                                       14, tint, 3);
+            }
+
+            // The cursor itself, in the active mode's colour: its point rests on the top of the
+            // slot's disc rather than in the middle of it, so the Pokemon, its shiny mark and its
+            // party badge all stay visible. On the top row the body runs up over the box-name pill
+            // -- deliberately, the way HOME's cursor does; it is drawn last, so it floats over the
+            // header instead of being clipped by it.
+            const int cx = g.centerX(cursorSlot), cy = g.centerY(cursorSlot);
+            fb.drawPointerCursor(cx, cy - g.discR - 3 + bob, kGridCursorH, cur);
         }
     }
 
@@ -192,34 +262,21 @@ namespace Panels {
             : ("Box " + std::to_string(screen.stSaveBox + 1));
         std::string bankLabel = screen.bank->boxDisplayName(screen.stBankBox);
 
-        int saveCursorRect[4] = {-1, -1, -1, -1};
-        int bankCursorRect[4] = {-1, -1, -1, -1};
+        PaneGeom saveGeom, bankGeom;
 
         drawPane(screen, fb, x, y, paneW, paneH, /*savePane*/true,
                  screen.stSaveBox, screen.stSaveSlot, saveFocused, entered,
-                 saveCols, rows, saveSlots, saveLabel, static_cast<int>(screen.trainer.getBoxCount()), saveCursorRect);
+                 saveCols, rows, saveSlots, saveLabel, static_cast<int>(screen.trainer.getBoxCount()), saveGeom);
 
         drawPane(screen, fb, x + paneW + gap, y, paneW, paneH, /*savePane*/false,
                  screen.stBankBox, screen.stBankSlot, bankFocused, entered,
-                 bankCols, rows, bankSlots, bankLabel, static_cast<int>(Bank::BANK_BOX_COUNT), bankCursorRect);
+                 bankCols, rows, bankSlots, bankLabel, static_cast<int>(Bank::BANK_BOX_COUNT), bankGeom);
 
-        // Carried Pokemon: lift it over the cursor with a soft shadow (no harsh outline).
-        if (entered && screen.heldPokemon) {
-            const int* r = saveFocused ? saveCursorRect : bankCursorRect;
-            if (r[0] >= 0) {
-                const int sp = (r[2] < r[3] ? r[2] : r[3]) - 6;
-                const int hx = r[0] + (r[2] - sp) / 2;
-                const int hy = r[1] - 12;  // lifted so it reads as "in hand"
-                fb.drawFilledEllipse(r[0] + r[2] / 2, r[1] + r[3] - 8, sp / 2 - 2, 5, Color(0, 0, 0, 90));
-                if (screen.heldPokemon->isEgg()) {
-                    fb.drawEgg(hx + sp / 2, hy + sp / 2, sp);  // held egg shows as an egg
-                } else {
-                    bool shiny = screen.heldPokemon->isShiny(screen.heldPokemon->id32(), std::string(screen.heldPokemon->species()));
-                    Sprite* sprite = SpriteManager::getIconSprite(screen.heldPokemon->speciesID(), screen.heldPokemon->form(), shiny);
-                    if (sprite && sprite->data)
-                        fb.drawImageScaled(hx, hy, sprite->width, sprite->height, sp, sp, sprite->data, sprite->channels);
-                }
-            }
+        // Cursor + carried block last, over BOTH panes: a group being carried from one side to the
+        // other must not be painted over by the destination pane's card.
+        if (entered) {
+            drawCarryAndCursor(screen, fb, saveFocused ? saveGeom : bankGeom,
+                               saveFocused ? screen.stSaveSlot : screen.stBankSlot);
         }
 
         // --- Info strip ---
@@ -236,30 +293,46 @@ namespace Panels {
         fb.drawFilledCircle(x + 22, iy + infoH / 2, 8, modeCol);
         fb.drawText(x + 38, iy + infoH / 2 - 11, modeName(screen.cursorMode), Colors::Text, TextStyle::Body);
 
-        // Right side: multi-selection count (Multi mode).
-        if (!screen.multiSel.empty()) {
-            std::string sel = std::to_string(screen.multiSel.size()) + " selected";
+        // Right side: how big the group in hand (or being swept out) is, in the mode colour.
+        std::string sel;
+        if (screen.carrying() && screen.carriedCount() > 1) {
+            sel = std::to_string(screen.carriedCount()) + " in hand ("
+                + std::to_string(screen.selectDimensions.first) + "x"
+                + std::to_string(screen.selectDimensions.second) + ")";
+        } else if (screen.currentlySelecting) {
+            sel = "Selecting - A grabs the group";
+        }
+        if (!sel.empty()) {
             int sw, sh; fb.measureText(sel, sw, sh);
-            fb.drawText(x + width - 16 - sw, iy + infoH / 2 - 11, sel, MultiColor, TextStyle::Body);
+            fb.drawText(x + width - 16 - sw, iy + infoH / 2 - 11, sel, Colors::CursorMulti, TextStyle::Body);
         }
 
         // Middle: the held Pokemon, else the one under the focused cursor. When the box-name header
         // is focused (slot == -1) there is no cursor mon, so prompt the rename instead of indexing.
         const int focusSlot = saveFocused ? screen.stSaveSlot : screen.stBankSlot;
-        const Pokemon::Pokemon* focus = screen.heldPokemon.get();
+        const bool holding = screen.carrying();
+        const Pokemon::Pokemon* focus = screen.firstCarried();
         if (!focus && focusSlot >= 0) {
             focus = saveFocused ? screen.trainer.boxes[screen.stSaveBox][focusSlot].get()
                                 : screen.bank->boxes[screen.stBankBox][focusSlot].get();
         }
 
         const int tx = x + 120;
-        if (focusSlot == -1 && !screen.heldPokemon) {
+        if (focusSlot == -1 && !holding) {
             fb.drawText(tx, iy + infoH / 2 - 11, "Box name selected - press A to rename", Colors::TextDim, TextStyle::Body);
+        } else if (holding && screen.carriedCount() > 1) {
+            // A whole group in hand: name the leader and say how many ride with it, rather than
+            // pretending one Pokemon is the whole payload.
+            std::string display = Names::getDisplayName(focus->speciesID(), focus->form(), std::string(focus->species()));
+            std::string line = "Holding: " + display + " +" + std::to_string(screen.carriedCount() - 1)
+                             + (screen.checkPutDownBounds() ? "   A places them here" : "   won't fit here");
+            fb.drawText(tx, iy + infoH / 2 - 11, line,
+                        screen.checkPutDownBounds() ? Colors::Text : Colors::Warning, TextStyle::Body);
         } else if (focus && focus->speciesID() != 0) {
             std::string name(focus->species());
             const bool shiny = focus->isShiny(focus->id32(), name);
             std::string display = Names::getDisplayName(focus->speciesID(), focus->form(), name);
-            std::string line = (screen.heldPokemon ? "Holding: " : "") + display + "   Lv. " + std::to_string(focus->level());
+            std::string line = (holding ? "Holding: " : "") + display + "   Lv. " + std::to_string(focus->level());
             fb.drawText(tx, iy + infoH / 2 - 11, line, Colors::Text, TextStyle::Body);
             int lw, lh; fb.measureText(line, lw, lh, TextStyle::Body);
             int mx = tx + lw + 10;
@@ -320,16 +393,19 @@ namespace Panels {
         drawPopupMenu(screen, fb, title, items, 5, screen.storageMenuIndex, disabled);
     }
 
+    // Options for the block in hand. There is deliberately no "move" entry: a carried group is moved
+    // by carrying it to the destination and pressing A, which is what makes placement positional.
     void drawStorageGroupMenu(TrainerViewScreen& screen, PKSEFramebuffer& fb) {
-        const std::string title = std::to_string(screen.multiSel.size()) + " selected";
-        static const char* const items[] = {"Move to other side", "Release", "Clear selection", "Cancel"};
-        drawPopupMenu(screen, fb, title, items, 4, screen.groupMenuIndex);
+        const int n = screen.carriedCount();
+        const std::string title = std::to_string(n) + (n == 1 ? " in hand" : " Pokemon in hand");
+        static const char* const items[] = {"Release all", "Put back where they came from", "Cancel"};
+        drawPopupMenu(screen, fb, title, items, 3, screen.groupMenuIndex);
     }
 
     void drawStorageReleaseConfirm(TrainerViewScreen& screen, PKSEFramebuffer& fb) {
         std::string msg;
         if (screen.releaseGroup) {
-            msg = "Release " + std::to_string(screen.multiSel.size()) + " Pokémon?";
+            msg = "Release " + std::to_string(screen.carriedCount()) + " Pokémon?";
         } else {
             const Pokemon::Pokemon* pk = screen.storageSlot(screen.releasePane, screen.releaseBox, screen.releaseSlot).get();
             const std::string who = (pk && pk->speciesID() != 0)
@@ -408,7 +484,7 @@ namespace Panels {
     }
 
     void drawStorageExitConfirm(TrainerViewScreen& screen, PKSEFramebuffer& fb) {
-        // The bank has unsaved changes; ask before leaving (PKSM-style). Bank saving is separate
+        // The bank has unsaved changes; ask before leaving (HOME-style). Bank saving is separate
         // from the game (X) save, so this is the bank's own persistence decision.
         static const char* const items[] = {"Save & Exit", "Discard changes", "Cancel"};
         drawPopupMenu(screen, fb, "Save bank changes?", items, 3, screen.storageExitConfirmIndex);

--- a/src/UI/SpriteManager.cpp
+++ b/src/UI/SpriteManager.cpp
@@ -138,7 +138,7 @@ namespace UI {
         std::string suffix = isShiny ? "s" : "";
         std::string sid = std::to_string(spriteId);
 
-        // Prefer the HD render (transparent Pokemon HOME PNG) for this sprite id, then
+        // Prefer the HD render (transparent HOME PNG) for this sprite id, then
         // fall back to the bundled 96px sprite.
         Sprite* sprite = loadSprite("sprites/pokemon_hd/" + sid + suffix + ".png");
         if (!sprite) {

--- a/src/UI/TrainerViewScreen.cpp
+++ b/src/UI/TrainerViewScreen.cpp
@@ -373,25 +373,51 @@ namespace UI {
         }
     }
 
+    // Non-null cells in the carried block (a block can contain holes -- see moveMon).
+    int TrainerViewScreen::carriedCount() const {
+        int n = 0;
+        for (const auto& p : moveMon) if (p) ++n;
+        return n;
+    }
+
+    const Pokemon::Pokemon* TrainerViewScreen::firstCarried() const {
+        for (const auto& p : moveMon) if (p) return p.get();
+        return nullptr;
+    }
+
+    // Put the whole carried block back where it was lifted from. Each cell prefers its own original
+    // slot; if something has since filled that slot, it falls back to any empty slot in the origin
+    // pane, because a carried Pokemon must never be dropped on the floor.
     void TrainerViewScreen::returnHeldToOrigin() {
-        if (!heldPokemon) return;
-        auto place = [&](int pane, int box, int slot) -> bool {
-            if (pane == 1 && !bank) return false;
-            auto& dst = (pane == 0) ? trainer.boxes[box][slot] : bank->boxes[box][slot];
-            if (!dst || dst->speciesID() == 0) { dst = std::move(heldPokemon); return true; }
+        if (!carrying()) return;
+        const int pane = heldPane;
+        if (pane == 1 && !bank) return;
+        const int slots = (pane == 0) ? static_cast<int>(trainer.getSlotsPerBox())
+                                      : static_cast<int>(Trainer::Bank::BANK_SLOTS_PER_BOX);
+        const int boxCount = (pane == 0) ? static_cast<int>(trainer.getBoxCount())
+                                         : static_cast<int>(Trainer::Bank::BANK_BOX_COUNT);
+        const int cols = (pane == 0) ? ((slots == 25) ? 5 : 6) : 6;
+        auto place = [&](int box, int slot, std::unique_ptr<Pokemon::Pokemon>& pk) -> bool {
+            if (box < 0 || box >= boxCount || slot < 0 || slot >= slots) return false;
+            if (storageSlotLocked(pane, box, slot)) return false;
+            auto& dst = storageSlot(pane, box, slot);
+            if (!dst || dst->speciesID() == 0) { dst = std::move(pk); return true; }   // species-0 = empty (S/V ghost)
             return false;
         };
-        // Prefer the exact origin; if it's since been filled, fall back to any empty slot in the
-        // origin pane so a carried Pokemon can never be dropped/lost.
-        if (place(heldPane, heldFromBox, heldFromSlot)) return;
-        const int slots = (heldPane == 0) ? static_cast<int>(trainer.getSlotsPerBox())
-                                          : static_cast<int>(Trainer::Bank::BANK_SLOTS_PER_BOX);
-        for (int s = 0; s < slots; ++s) if (place(heldPane, heldFromBox, s)) return;
-        const int boxCount = (heldPane == 0) ? static_cast<int>(trainer.getBoxCount())
-                                             : static_cast<int>(Trainer::Bank::BANK_BOX_COUNT);
-        for (int b = 0; b < boxCount; ++b)
-            for (int s = 0; s < slots; ++s)
-                if (place(heldPane, b, s)) return;
+        const int w = selectDimensions.first > 0 ? selectDimensions.first : 1;
+        for (size_t i = 0; i < moveMon.size(); ++i) {
+            if (!moveMon[i]) continue;
+            const int x = static_cast<int>(i) % w, y = static_cast<int>(i) / w;
+            int box = heldFromBox, slot = heldFromSlot + x + y * cols;
+            while (slot >= slots) { slot -= slots; ++box; }        // defensive: a grab is bounds-checked to one box
+            if (place(box, slot, moveMon[i])) continue;
+            bool placed = false;
+            for (int b = 0; b < boxCount && !placed; ++b)
+                for (int s = 0; s < slots && !placed; ++s)
+                    placed = place(b, s, moveMon[i]);
+        }
+        moveMon.clear();
+        selectDimensions = {0, 0};
     }
 
     // Reference to a storage slot's unique_ptr (pane 0 = save boxes, 1 = bank). Callers must
@@ -454,11 +480,6 @@ namespace UI {
         return false;
     }
 
-    // Prepare the carried (single) mon for placement into `pane`. Thin wrapper over convertForPane.
-    bool TrainerViewScreen::prepareHeldForPane(int pane) {
-        return convertForPane(heldPokemon, pane);
-    }
-
     // True if placing `pk` into `pane` would run a Let's Go conversion (exactly one side is LGPE), which
     // resets AVs/EVs -> the user is asked to acknowledge it. Only save-pane (0) placements convert; the
     // bank (1) stores native bytes, so a deposit never resets anything.
@@ -469,13 +490,11 @@ namespace UI {
         return srcGG != dstGG;
     }
 
-    // True if any mon in the current multi-selection would run an LGPE conversion when dropped into destPane.
-    bool TrainerViewScreen::selectionInvolvesLgpe(int destPane) const {
-        if (destPane != 0 || !bank) return false;
-        for (const auto& r : multiSel) {
-            const auto& p = (r.pane == 0) ? trainer.boxes[r.box][r.slot] : bank->boxes[r.box][r.slot];
+    // True if any mon in the carried block would run an LGPE conversion when dropped into destPane.
+    bool TrainerViewScreen::blockInvolvesLgpe(int destPane) const {
+        if (destPane != 0) return false;
+        for (const auto& p : moveMon)
             if (p && lgpeConversionInvolved(destPane, p.get())) return true;
-        }
         return false;
     }
 
@@ -489,13 +508,11 @@ namespace UI {
             && pk->getGameGroup() != Enums::GameVersion::FRLG;
     }
 
-    // True if any mon in the current multi-selection would run a Gen 3 downgrade when dropped into destPane.
-    bool TrainerViewScreen::selectionInvolvesGen3Downgrade(int destPane) const {
-        if (destPane != 0 || !bank || trainer.getGameGroup() != Enums::GameVersion::FRLG) return false;
-        for (const auto& r : multiSel) {
-            const auto& p = (r.pane == 0) ? trainer.boxes[r.box][r.slot] : bank->boxes[r.box][r.slot];
+    // True if any mon in the carried block would run a Gen 3 downgrade when dropped into destPane.
+    bool TrainerViewScreen::blockInvolvesGen3Downgrade(int destPane) const {
+        if (destPane != 0 || trainer.getGameGroup() != Enums::GameVersion::FRLG) return false;
+        for (const auto& p : moveMon)
             if (p && p->getGameGroup() != Enums::GameVersion::FRLG) return true;
-        }
         return false;
     }
 
@@ -840,7 +857,7 @@ namespace UI {
         postStatus("Money set to $" + std::to_string(newMoney) + ".", 150);
     }
 
-    // A backup's leaf folder name IS its name everywhere in the UI (PKSM does the same), so this is
+    // A backup's leaf folder name IS its name everywhere in the UI, so this is
     // what the user recognises when we report where a save went.
     static std::string leafName(const std::string& path) {
         const size_t slash = path.find_last_of('/');
@@ -979,9 +996,9 @@ namespace UI {
     //     bag caps stacks at 99 and spills into fresh slots -- not Gen 3's model.
     //   * PKHeX applies no Gen 3 special-casing anywhere: PlayerBag3FRLG declares 999 like every
     //     other game, and InventoryPouch3 adds no count logic at all.
-    //   * PKSM on real Gen 3 hardware permits the full u16 (65535), confirming Gen 3 does not
-    //     enforce a low cap. We stay at PKHeX's 999 rather than matching PKSM: it is the
-    //     legality-aware bound, and nothing is gained by allowing counts no game will ever show.
+    //   * Other on-hardware Gen 3 editors permit the full u16 (65535), confirming Gen 3 does not
+    //     enforce a low cap. We stay at PKHeX's 999 anyway: it is the legality-aware bound, and
+    //     nothing is gained by allowing counts no game will ever show.
     int TrainerViewScreen::currentItemMaxCount() const {
         using GV = Enums::GameVersion;
         const int c = selectedCategory;
@@ -1025,157 +1042,286 @@ namespace UI {
         snapshotEditTarget();    // dirty-check baseline (unused for the creator: it has Keep/Discard)
     }
 
-    // Green "Move": bulk-move the multi-selection into the opposite pane, filling empty slots from
-    // that pane's current box forward. Convertible mons move; any that can't convert into the
-    // destination game or don't fit stay selected (D5), and the user is told what was left and why.
-    void TrainerViewScreen::transferSelectionToOtherPane() {
-        if (multiSel.empty() || !bank) return;
-        const int from = multiSel.front().pane;
-        const int to = 1 - from;
-        const int dSlots = (to == 0) ? static_cast<int>(trainer.getSlotsPerBox()) : static_cast<int>(Trainer::Bank::BANK_SLOTS_PER_BOX);
-        const int dBoxes = (to == 0) ? static_cast<int>(trainer.getBoxCount()) : static_cast<int>(Trainer::Bank::BANK_BOX_COUNT);
-        int b = (to == 0) ? stSaveBox : stBankBox;
-        int s = 0;
-        std::vector<SlotRef> leftover;
-        int moved = 0, blocked = 0, nofit = 0;
-        std::string firstName;
-        const char* firstWhy = nullptr;
-        for (const auto& src : multiSel) {
-            auto& srcPtr = storageSlot(src.pane, src.box, src.slot);
-            if (!srcPtr) continue;
-            // Cross-game into a save: skip (keep selected) a foreign mon with no conversion route, and
-            // move the rest -- don't strand the whole group behind one blocker (D5).
-            if (to == 0 && srcPtr->getGameGroup() != trainer.getGameGroup()) {
-                Conversion::Result res;
-                if (!Conversion::canConvert(*srcPtr, trainer.getGameGroup(), res)) {
-                    ++blocked;
-                    if (!firstWhy) {
-                        firstName = Names::getDisplayName(srcPtr->speciesID(), srcPtr->form(),
-                                                          Trainer::getSpeciesName(srcPtr->speciesID()));
-                        firstWhy  = Conversion::resultMessage(res);
-                    }
-                    leftover.push_back(src);
-                    continue;
-                }
-            }
-            bool placed = false;
-            while (b < dBoxes) {
-                if (s >= dSlots) { s = 0; ++b; continue; }
-                if (!storageSlotLocked(to, b, s)) {
-                    auto& dst = storageSlot(to, b, s);
-                    // Treat a non-null species-0 "ghost" slot (an S/V encrypted-blank) as empty, same
-                    // as the single-move + returnHeldToOrigin do — otherwise a save-side box that's
-                    // full of ghosts has "no empty slot" and the moved mons get dropped.
-                    if (!dst || dst->speciesID() == 0) {
-                        convertForPane(srcPtr, to);      // verified convertible above (no-op for the bank)
-                        dst = std::move(srcPtr); ++s; placed = true; ++moved; break;
-                    }
-                }
-                ++s;
-            }
-            if (!placed) { leftover.push_back(src); ++nofit; }
-        }
-        multiSel = leftover;
-        if (moved > 0) hasUnsavedChanges = true;
+    // ---------------------------------------------------------------------------------------------
+    // HOME-style rectangle select + block carry.
+    //
+    // The model, in full: A anchors a corner, moving the cursor rubber-bands a rectangle, A again
+    // lifts every slot inside it into `moveMon` (row-major, holes kept as nulls) and snaps the cursor
+    // to the rectangle's top-left. From then on the block rides the cursor -- across boxes and across
+    // panes -- and A drops it so that cell (x, y) lands in slot `cursor + x + y*cols`. Landing is
+    // POSITIONAL, not "fill the next free slot": the arrangement you picked up is the arrangement you
+    // put down, and whatever occupied those slots comes back up into your hands (a block swap).
+    //
+    // Let's Go is the documented exception. Its storage is one gapless 1000-slot list, so a hole is
+    // not representable; the block still lands at the exact cursor slot, then compactStorage() closes
+    // any gap on the next frame, which slides the mons forward. That is the game's rule, not ours.
+    // ---------------------------------------------------------------------------------------------
 
-        // Report what stayed behind: conversion blockers first (actionable — deselect them), then a
-        // plain "didn't fit" if the destination simply filled up.
-        if (blocked > 0) {
-            storageStatus = "Moved the rest; " + std::to_string(blocked) + " can't go in this game ("
-                          + firstName + (blocked > 1 ? " +" + std::to_string(blocked - 1) : "") + ")";
-            storageStatusFrames = 180;
-        } else if (nofit > 0) {
-            storageStatus = std::to_string(nofit) + (nofit == 1 ? " mon" : " mons")
-                          + " didn't fit - the destination box is full";
-            storageStatusFrames = 180;
+    // Column count of a pane's grid. LGPE's save boxes are 5x5 (25 slots); everything else is 6x5.
+    int TrainerViewScreen::paneCols(int pane) const {
+        if (pane != 0) return 6;
+        return static_cast<int>(trainer.getSlotsPerBox()) == 25 ? 5 : 6;
+    }
+
+    int TrainerViewScreen::paneSlots(int pane) const {
+        return pane == 0 ? static_cast<int>(trainer.getSlotsPerBox())
+                         : static_cast<int>(Trainer::Bank::BANK_SLOTS_PER_BOX);
+    }
+
+    int TrainerViewScreen::paneBoxes(int pane) const {
+        return pane == 0 ? static_cast<int>(trainer.getBoxCount())
+                         : static_cast<int>(Trainer::Bank::BANK_BOX_COUNT);
+    }
+
+    void TrainerViewScreen::cancelSelection() {
+        currentlySelecting = false;
+        if (!carrying()) selectDimensions = {0, 0};
+    }
+
+    // Move mode: lift the slot under the cursor as a 1x1 block. Single and multi carry share one
+    // representation, so every later step (drawing, bounds, put-down, B-to-return) is written once.
+    void TrainerViewScreen::pickupSingle() {
+        if (!bank) return;
+        const int pane = storageFocusPane;
+        const int box = (pane == 0) ? stSaveBox : stBankBox;
+        const int slot = (pane == 0) ? stSaveSlot : stBankSlot;
+        if (slot < 0 || slot >= paneSlots(pane)) return;
+        if (storageSlotLocked(pane, box, slot)) return;      // LGPE party member: its slot is pinned
+        auto& src = storageSlot(pane, box, slot);
+        if (!src || src->speciesID() == 0) return;           // species-0 = empty (S/V ghost)
+
+        moveMon.clear();
+        moveMon.push_back(std::move(src));
+        selectDimensions = {1, 1};
+        heldPane = pane; heldFromBox = box; heldFromSlot = slot;
+    }
+
+    // Multi mode: the first A anchors the rectangle at the cursor, the second grabs it.
+    void TrainerViewScreen::pickupMulti() {
+        const int pane = storageFocusPane;
+        const int slot = (pane == 0) ? stSaveSlot : stBankSlot;
+        if (slot < 0 || slot >= paneSlots(pane)) return;
+        if (currentlySelecting) {
+            grabSelection(true);
+            return;
+        }
+        const int cols = paneCols(pane);
+        selectDimensions   = {slot % cols, slot / cols};     // anchor cell, NOT dimensions yet
+        selectPane         = pane;
+        selectBox          = (pane == 0) ? stSaveBox : stBankBox;
+        currentlySelecting = true;
+    }
+
+    // Lift (remove = true) or copy (remove = false) every slot inside the anchored rectangle into
+    // moveMon, then snap the cursor to the rectangle's top-left so the block sits under the pointer.
+    void TrainerViewScreen::grabSelection(bool remove) {
+        if (!currentlySelecting || !bank) return;
+        const int pane = selectPane;
+        const int box = selectBox;
+        const int cols = paneCols(pane);
+        const int slots = paneSlots(pane);
+        const int slot = (pane == 0) ? stSaveSlot : stBankSlot;
+        if (slot < 0 || slot >= slots) { cancelSelection(); return; }
+
+        const int curX = slot % cols, curY = slot / cols;
+        const int ax = selectDimensions.first, ay = selectDimensions.second;
+        const int baseX = std::min(ax, curX), baseY = std::min(ay, curY);
+        const int w = std::abs(ax - curX) + 1, h = std::abs(ay - curY) + 1;
+
+        moveMon.clear();
+        moveMon.reserve(static_cast<size_t>(w) * static_cast<size_t>(h));
+        int lockedLeft = 0;
+        for (int y = 0; y < h; ++y) {
+            for (int x = 0; x < w; ++x) {
+                const int s = (baseY + y) * cols + (baseX + x);
+                if (s >= slots) { moveMon.push_back(nullptr); continue; }
+                // A party-linked slot stays put: Let's Go's party points at box slots by INDEX, so
+                // carrying one away would leave that pointer aimed at whatever slid in behind it.
+                // It becomes a hole in the block rather than blocking the whole grab.
+                if (storageSlotLocked(pane, box, s)) { moveMon.push_back(nullptr); ++lockedLeft; continue; }
+                auto& src = storageSlot(pane, box, s);
+                if (!src || src->speciesID() == 0) { moveMon.push_back(nullptr); continue; }
+                if (remove) {
+                    moveMon.push_back(std::move(src));
+                } else {
+                    moveMon.push_back(src->clone());        // duplicate: leave the original in place
+                }
+            }
+        }
+
+        selectDimensions   = {w, h};
+        heldPane = pane; heldFromBox = box; heldFromSlot = baseY * cols + baseX;
+        currentlySelecting = false;
+
+        if (remove && carriedCount() > 0) hasUnsavedChanges = true;
+        if (lockedLeft > 0)
+            postStatus(std::to_string(lockedLeft) + " party-linked slot(s) stayed behind.", 180);
+
+        // Trim first, THEN put the cursor on the block's top-left cell -- scrunching moves that
+        // corner, and a cursor left on the untrimmed corner would draw the block offset from the
+        // Pokemon that were just lifted. A rectangle that caught nothing leaves the cursor alone.
+        postPickup();
+        if (carrying()) {
+            storageFocusPane = pane;
+            if (pane == 0) { stSaveBox = box; stSaveSlot = heldFromSlot; }
+            else           { stBankBox = box; stBankSlot = heldFromSlot; }
         }
     }
 
-    // Green move: drop the whole multi-selection into the destination pane, filling empty slots
-    // from (destBox, destSlot) forward. Sources are extracted first (in visual order) so a move
-    // within the same pane can't collide with its own sources.
-    void TrainerViewScreen::moveSelectionTo(int destPane, int destBox, int destSlot) {
-        if (multiSel.empty() || !bank) return;
-        // Keep the group's visual order at the destination, and (for a same-pane move) extract every
-        // source before writing any slot so a source can't be clobbered by an earlier placement.
-        std::vector<SlotRef> order = multiSel;
-        std::sort(order.begin(), order.end(), [](const SlotRef& a, const SlotRef& b) {
-            return a.box != b.box ? a.box < b.box : a.slot < b.slot;
-        });
-
-        // Cross-game into a save (pane 0): convert each foreign mon into the open game's format. Grab
-        // the ones that HAVE a route now and leave the rest selected in place, rather than denying the
-        // whole drop for one blocker (D5). Bank deposits (destPane 1) never block -- native bytes.
-        std::vector<std::unique_ptr<Pokemon::Pokemon>> grabbed;
-        std::vector<SlotRef> leftover;
-        int blocked = 0;
-        std::string firstName;
-        const char* firstWhy = nullptr;
-        for (const auto& r : order) {
-            auto& src = storageSlot(r.pane, r.box, r.slot);
-            if (!src) continue;
-            if (destPane == 0 && src->getGameGroup() != trainer.getGameGroup()) {
-                Conversion::Result res;
-                if (!Conversion::canConvert(*src, trainer.getGameGroup(), res)) {
-                    ++blocked;
-                    if (!firstWhy) {
-                        firstName = Names::getDisplayName(src->speciesID(), src->form(),
-                                                          Trainer::getSpeciesName(src->speciesID()));
-                        firstWhy  = Conversion::resultMessage(res);
-                    }
-                    leftover.push_back(r);
-                    continue;
-                }
-            }
-            grabbed.push_back(std::move(src));
+    // Drop a block whose every cell is null -- otherwise the hands stay "full" of nothing and the
+    // next A would put empties down over real Pokemon.
+    void TrainerViewScreen::postPickup() {
+        if (currentlySelecting) return;
+        if (carriedCount() == 0) {
+            moveMon.clear();
+            selectDimensions = {0, 0};
+            return;
         }
-        multiSel = leftover;   // blocked mons stay selected and untouched in their slots
+        scrunchSelection();
+    }
 
-        if (grabbed.empty()) {
-            // Nothing had a route -- name the first blocker so the user knows what to do.
-            if (blocked > 0) {
-                storageStatus = firstName + ": " + firstWhy
-                              + (blocked > 1 ? "  (+" + std::to_string(blocked - 1) + " more)" : "")
-                              + " - can't go in this game";
-                storageStatusFrames = 180;
-            }
+    // Trim fully-empty rows and columns off the block's edges. Selecting a loose
+    // rectangle around three Pokemon should hand you a block sized to those three, not to the box
+    // area you swept -- otherwise the bounds check refuses drops that would obviously have fitted.
+    void TrainerViewScreen::scrunchSelection() {
+        int w = selectDimensions.first, h = selectDimensions.second;
+        if (w <= 1 && h <= 1) return;
+        if (w <= 0 || h <= 0 || static_cast<int>(moveMon.size()) != w * h) return;
+
+        auto colEmpty = [&](int c) {
+            for (int r = 0; r < h; ++r) if (moveMon[r * w + c]) return false;
+            return true;
+        };
+        auto rowEmpty = [&](int r) {
+            for (int c = 0; c < w; ++c) if (moveMon[r * w + c]) return false;
+            return true;
+        };
+        int first = 0, last = w - 1;
+        while (first <= last && colEmpty(first)) ++first;
+        while (last > first && colEmpty(last)) --last;
+        int top = 0, bottom = h - 1;
+        while (top <= bottom && rowEmpty(top)) ++top;
+        while (bottom > top && rowEmpty(bottom)) --bottom;
+        if (first > last || top > bottom) return;            // all empty; postPickup already handled it
+        if (first == 0 && last == w - 1 && top == 0 && bottom == h - 1) return;
+
+        std::vector<std::unique_ptr<Pokemon::Pokemon>> packed;
+        packed.reserve(static_cast<size_t>(last - first + 1) * static_cast<size_t>(bottom - top + 1));
+        for (int r = top; r <= bottom; ++r)
+            for (int c = first; c <= last; ++c)
+                packed.push_back(std::move(moveMon[r * w + c]));
+        moveMon = std::move(packed);
+        selectDimensions = {last - first + 1, bottom - top + 1};
+        // The origin moves with the trim, so B still returns each cell to the slot it came from.
+        const int cols = paneCols(heldPane);
+        heldFromSlot += top * cols + first;
+    }
+
+    // Does the block fit in the focused pane starting at the cursor cell? A block may not hang off
+    // the right edge or past the bottom row -- that is what makes "lands in the exact slot" a rule
+    // rather than a hope.
+    bool TrainerViewScreen::checkPutDownBounds() const {
+        if (!carrying()) return false;
+        const int pane = storageFocusPane;
+        const int slot = (pane == 0) ? stSaveSlot : stBankSlot;
+        if (slot < 0) return false;
+        const int cols = paneCols(pane);
+        const int slots = paneSlots(pane);
+        const int rows = (slots + cols - 1) / cols;
+        const int c = slot % cols, r = slot / cols;
+        return c + selectDimensions.first <= cols
+            && r + selectDimensions.second <= rows
+            && slot + (selectDimensions.first - 1) + (selectDimensions.second - 1) * cols < slots;
+    }
+
+    // Put the block down at the cursor: cell (x, y) -> slot + x + y*cols, exactly. Each cell SWAPS
+    // with whatever is in its destination, so the displaced Pokemon come back up into your hands as
+    // a block of the same shape (HOME's behaviour, and what makes a positional move reversible).
+    //
+    // Cells that cannot land -- a locked (party-linked) destination, or a cross-game mon with no
+    // conversion route into this save -- stay in the block and stay untouched, so one blocker never
+    // strands the rest of the group.
+    void TrainerViewScreen::putDownBlock() {
+        if (!carrying() || !bank) return;
+        const int pane = storageFocusPane;
+        const int box = (pane == 0) ? stSaveBox : stBankBox;
+        const int slot = (pane == 0) ? stSaveSlot : stBankSlot;
+        const int cols = paneCols(pane);
+        const int slots = paneSlots(pane);
+        if (!checkPutDownBounds()) {
+            postStatus("That group doesn't fit here - move to a slot with room for it.", 180);
             return;
         }
 
-        // Verified convertible above; convert each foreign grabbed mon into the save's format.
-        if (destPane == 0)
-            for (auto& g : grabbed) convertForPane(g, destPane);
+        const int w = selectDimensions.first, h = selectDimensions.second;
+        int placed = 0, lockedHit = 0, blocked = 0;
+        std::string firstName;
+        const char* firstWhy = nullptr;
 
-        const int dSlots = (destPane == 0) ? static_cast<int>(trainer.getSlotsPerBox()) : static_cast<int>(Trainer::Bank::BANK_SLOTS_PER_BOX);
-        const int dBoxes = (destPane == 0) ? static_cast<int>(trainer.getBoxCount()) : static_cast<int>(Trainer::Bank::BANK_BOX_COUNT);
-        int b = destBox, s = destSlot;
-        size_t idx = 0;
-        while (idx < grabbed.size() && b < dBoxes) {
-            if (s >= dSlots) { s = 0; ++b; continue; }
-            if (!storageSlotLocked(destPane, b, s)) {
-                auto& dst = storageSlot(destPane, b, s);
-                if (!dst || dst->speciesID() == 0) { dst = std::move(grabbed[idx]); ++idx; }  // species-0 = empty (S/V ghost)
-            }
-            ++s;
-        }
-        // Any leftover (destination past the start was full): drop into the first empty slot anywhere.
-        for (; idx < grabbed.size(); ++idx) {
-            bool placed = false;
-            for (int bb = 0; bb < dBoxes && !placed; ++bb)
-                for (int ss = 0; ss < dSlots && !placed; ++ss)
-                    if (!storageSlotLocked(destPane, bb, ss)) {
-                        auto& d = storageSlot(destPane, bb, ss);
-                        if (!d || d->speciesID() == 0) { d = std::move(grabbed[idx]); placed = true; }  // species-0 = empty
+        for (int y = 0; y < h; ++y) {
+            for (int x = 0; x < w; ++x) {
+                const size_t idx = static_cast<size_t>(y) * static_cast<size_t>(w) + static_cast<size_t>(x);
+                const int dSlot = slot + x + y * cols;
+                if (dSlot < 0 || dSlot >= slots) continue;
+                // Never disturb a party-linked slot -- not even with an empty cell, which would
+                // silently delete a party member out from under its pointer.
+                if (storageSlotLocked(pane, box, dSlot)) {
+                    if (moveMon[idx]) ++lockedHit;
+                    continue;
+                }
+                if (moveMon[idx]) {
+                    // Ask whether there is a route (for a species-named message), then honour what
+                    // the conversion ACTUALLY returns. Writing an unconverted foreign Pokemon into a
+                    // save is what produces a Bad Egg in game, so a failure here must not fall through.
+                    const bool foreign = (pane == 0 && moveMon[idx]->getGameGroup() != trainer.getGameGroup());
+                    Conversion::Result res{};
+                    const bool routed = !foreign || Conversion::canConvert(*moveMon[idx], trainer.getGameGroup(), res);
+                    if (!routed || !convertForPane(moveMon[idx], pane)) {
+                        ++blocked;
+                        if (!firstWhy) {
+                            firstName = Names::getDisplayName(moveMon[idx]->speciesID(), moveMon[idx]->form(),
+                                                              Trainer::getSpeciesName(moveMon[idx]->speciesID()));
+                            firstWhy  = routed ? "conversion failed" : Conversion::resultMessage(res);
+                        }
+                        continue;                                   // leave it in hand, untouched
                     }
+                    ++placed;
+                }
+                auto& dst = storageSlot(pane, box, dSlot);
+                std::swap(dst, moveMon[idx]);                       // block swap: the occupant comes up
+                if (moveMon[idx] && moveMon[idx]->speciesID() == 0) moveMon[idx] = nullptr;  // ghost -> hole
+            }
         }
-        hasUnsavedChanges = true;
 
-        // Some were left behind — say so, or a partial move reads as a full one and the user doesn't
-        // notice the blocked mons still sitting selected.
+        if (placed > 0) hasUnsavedChanges = true;
+        // The block's origin is now this drop site, so B returns the swapped-out Pokemon here.
+        heldPane = pane; heldFromBox = box; heldFromSlot = slot;
+        postPickup();                       // may trim the swapped-out leftovers, moving heldFromSlot
+        if (carrying()) {                   // keep the cursor on the leftovers' top-left corner
+            if (pane == 0) stSaveSlot = heldFromSlot; else stBankSlot = heldFromSlot;
+        }
+
         if (blocked > 0) {
-            storageStatus = "Moved the rest; " + std::to_string(blocked) + " can't go in this game ("
-                          + firstName + (blocked > 1 ? " +" + std::to_string(blocked - 1) : "") + ")";
-            storageStatusFrames = 180;
+            postStatus(firstName + ": " + (firstWhy ? firstWhy : "no transfer route")
+                       + (blocked > 1 ? "  (+" + std::to_string(blocked - 1) + " more)" : "")
+                       + " - still in hand", 240);
+        } else if (lockedHit > 0) {
+            postStatus(std::to_string(lockedHit) + " couldn't land on a party-linked slot - still in hand", 240);
+        }
+    }
+
+    // The A press in the storage grid: put the block down if hands are full,
+    // otherwise pick up according to the active mode.
+    void TrainerViewScreen::storagePickup() {
+        if (carrying()) {
+            putDownBlock();
+            return;
+        }
+        switch (cursorMode) {
+            case CursorMode::Multi: pickupMulti(); break;
+            case CursorMode::Move:  pickupSingle(); postPickup(); break;
+            case CursorMode::Menu:
+            default: break;   // handled by the caller (opens the per-Pokemon menu)
         }
     }
 
@@ -1224,54 +1370,49 @@ namespace UI {
         // Accessors that always target the currently-focused pane.
         auto curBox  = [&]() -> int& { return storageFocusPane == 0 ? stSaveBox : stBankBox; };
         auto curSlot = [&]() -> int& { return storageFocusPane == 0 ? stSaveSlot : stBankSlot; };
-        auto colsOf  = [&](int pane) { return pane == 0 ? ((static_cast<int>(trainer.getSlotsPerBox()) == 25) ? 5 : 6) : 6; };
-        auto slotsOf = [&](int pane) { return pane == 0 ? static_cast<int>(trainer.getSlotsPerBox())
-                                                        : static_cast<int>(Trainer::Bank::BANK_SLOTS_PER_BOX); };
-        auto boxCntOf = [&](int pane) { return pane == 0 ? static_cast<int>(trainer.getBoxCount())
-                                                         : static_cast<int>(Trainer::Bank::BANK_BOX_COUNT); };
         // The focused pane's box name is renamable when it's the bank (always) or a save that stores
         // box names (LGPE does not). Gates whether Up/Down can land on the box-name header.
         auto headerRenamable = [&]() { return storageFocusPane == 1 || trainer.supportsBoxNames(); };
-        auto slotPtr = [&](int pane, int box, int slot) -> std::unique_ptr<Pokemon::Pokemon>& {
-            return pane == 0 ? trainer.boxes[box][slot] : bank->boxes[box][slot];
-        };
-        // A save-pane slot that is a party member (LGPE) is locked: removing it from storage would
-        // orphan its party pointer. No-op for SWSH/LZA (party is a separate structure -> pos 0).
-        auto isLocked = [&](int pane, int box, int slot) {
-            return pane == 0 && trainer.getPartyPosition(box, slot) > 0;
-        };
+        auto isLocked = [&](int pane, int box, int slot) { return storageSlotLocked(pane, box, slot); };
         auto occupied = [&](int pane, int box, int slot) {
-            const auto& p = slotPtr(pane, box, slot);
+            const auto& p = storageSlot(pane, box, slot);
             return p && p->speciesID() != 0;
         };
 
-        // Y: cycle mode Menu -> Move -> Multi (only with empty hands). Leaving Multi clears the selection.
-        const bool holding = (heldPokemon != nullptr);
-        if ((kDown & HidNpadButton_Y) && !holding) {
+        const bool holding = carrying();
+
+        // Y: cycle mode Menu -> Move -> Multi. Only with empty hands and no rectangle in progress,
+        // so a mode switch can never orphan a carried block or a half-drawn selection.
+        if ((kDown & HidNpadButton_Y) && !holding && !currentlySelecting) {
             cursorMode = cursorMode == CursorMode::Menu ? CursorMode::Move
                        : cursorMode == CursorMode::Move ? CursorMode::Multi : CursorMode::Menu;
-            if (cursorMode != CursorMode::Multi) multiSel.clear();
         }
 
-        // L/R: change the focused pane's box (wrap); keep the cursor slot in range.
-        if (kDown & HidNpadButton_L) curBox() = (curBox() - 1 + boxCntOf(storageFocusPane)) % boxCntOf(storageFocusPane);
-        if (kDown & HidNpadButton_R) curBox() = (curBox() + 1) % boxCntOf(storageFocusPane);
-        if (curSlot() >= slotsOf(storageFocusPane)) curSlot() = slotsOf(storageFocusPane) - 1;
+        // L/R: change the focused pane's box (wrap); keep the cursor slot in range. Changing box
+        // abandons an in-progress rectangle -- it was anchored in the box you just left.
+        if (kDown & (HidNpadButton_L | HidNpadButton_R)) {
+            const int bc = paneBoxes(storageFocusPane);
+            if (kDown & HidNpadButton_L) curBox() = (curBox() - 1 + bc) % bc;
+            if (kDown & HidNpadButton_R) curBox() = (curBox() + 1) % bc;
+            if (currentlySelecting) cancelSelection();
+        }
+        if (curSlot() >= paneSlots(storageFocusPane)) curSlot() = paneSlots(storageFocusPane) - 1;
 
         // D-pad: move within the focused pane; Left/Right cross panes at the horizontal edges.
-        const int cols = colsOf(storageFocusPane);
-        const int slots = slotsOf(storageFocusPane);
-        constexpr int rows = 5;
+        const int cols = paneCols(storageFocusPane);
+        const int slots = paneSlots(storageFocusPane);
+        const int rows = (slots + cols - 1) / cols;
         // curSlot() == -1 is the "box-name header focused" state (rename via A or a tap). Up from the
-        // top row lands on it and Down leaves it -- but only where the header is renamable and the
-        // hands are empty, so LGPE (no box names) and mid-carry keep the plain top<->bottom wrap.
+        // top row lands on it and Down leaves it -- but only where the header is renamable and nothing
+        // is in hand or being selected, so LGPE (no box names) and mid-carry keep the plain wrap.
+        const bool headerReachable = headerRenamable() && !holding && !currentlySelecting;
         if (kDown & HidNpadButton_Up) {
             if (curSlot() == -1) {
                 curSlot() = (rows - 1) * cols;                        // header -> bottom row (wrap)
                 if (curSlot() >= slots) curSlot() = slots - 1;
             } else {
                 int r = curSlot() / cols, c = curSlot() % cols;
-                if (r == 0 && headerRenamable() && !holding) {
+                if (r == 0 && headerReachable) {
                     curSlot() = -1;                                  // top row -> header
                 } else {
                     r = (r - 1 + rows) % rows;
@@ -1285,7 +1426,7 @@ namespace UI {
                 curSlot() = 0;                                        // header -> top-left
             } else {
                 int r = curSlot() / cols, c = curSlot() % cols;
-                if (r == rows - 1 && headerRenamable() && !holding) {
+                if (r == rows - 1 && headerReachable) {
                     curSlot() = -1;                                  // bottom row -> header (wrap)
                 } else {
                     r = (r + 1) % rows;
@@ -1295,55 +1436,63 @@ namespace UI {
             }
         }
         if (kDown & HidNpadButton_Left) {
-            if (curSlot() == -1) {                                    // on the header: ◀ cycles the box
-                curBox() = (curBox() - 1 + boxCntOf(storageFocusPane)) % boxCntOf(storageFocusPane);
+            if (curSlot() == -1) {                                    // on the header: the box arrow cycles the box
+                curBox() = (curBox() - 1 + paneBoxes(storageFocusPane)) % paneBoxes(storageFocusPane);
             } else {
                 int c = curSlot() % cols;
                 if (c > 0) {
                     curSlot() -= 1;
-                } else if (storageFocusPane == 1) {
+                } else if (storageFocusPane == 1 && !currentlySelecting) {
+                    // A rectangle lives in one box of one pane, so crossing panes is only allowed
+                    // when nothing is being selected. A carried block may cross freely.
                     const int r = curSlot() / cols;
                     storageFocusPane = 0;
-                    const int scols = colsOf(0);
+                    const int scols = paneCols(0);
                     stSaveSlot = r * scols + (scols - 1);
-                    if (stSaveSlot >= slotsOf(0)) stSaveSlot = slotsOf(0) - 1;
+                    if (stSaveSlot >= paneSlots(0)) stSaveSlot = paneSlots(0) - 1;
                 }
             }
         }
         if (kDown & HidNpadButton_Right) {
-            if (curSlot() == -1) {                                    // on the header: ▶ cycles the box
-                curBox() = (curBox() + 1) % boxCntOf(storageFocusPane);
+            if (curSlot() == -1) {                                    // on the header: the box arrow cycles the box
+                curBox() = (curBox() + 1) % paneBoxes(storageFocusPane);
             } else {
                 int c = curSlot() % cols;
                 if (c < cols - 1 && curSlot() + 1 < slots) {
                     curSlot() += 1;
-                } else if (storageFocusPane == 0) {
+                } else if (storageFocusPane == 0 && !currentlySelecting) {
                     const int r = curSlot() / cols;
                     storageFocusPane = 1;
-                    stBankSlot = r * colsOf(1);  // col 0 of the bank pane
+                    stBankSlot = r * paneCols(1);  // col 0 of the bank pane
                 }
             }
         }
 
         const int pane = storageFocusPane, box = curBox(), slot = curSlot();
 
-        // Minus: in Multi mode with a selection, open the group menu.
-        if ((kDown & HidNpadButton_Minus) && !holding &&
-            cursorMode == CursorMode::Multi && !multiSel.empty()) {
+        // Minus: options for the block in hand (Release all / Return to origin / Cancel).
+        if ((kDown & HidNpadButton_Minus) && holding) {
             groupMenuActive = true;
             groupMenuIndex = 0;
             return;
         }
 
-        // X: sort the focused box. Free here -- the global X-to-save handler deliberately skips
-        // the storage view, since the bank saves via its own B -> Save/Discard prompt. Suppressed while
-        // carrying a Pokemon, so a sort can never run with one held out of the grid and lose it.
-        if ((kDown & HidNpadButton_X) && !holding) {
-            sortStorageBox(storageFocusPane, storageFocusPane == 0 ? stSaveBox : stBankBox);
-            return;
+        // X: while drawing a rectangle it DUPLICATES the selection (grab a copy
+        // and leave the originals in place). Otherwise it sorts the focused box. Suppressed while
+        // carrying, so a sort can never run with Pokemon held out of the grid and lose them.
+        if (kDown & HidNpadButton_X) {
+            if (currentlySelecting) {
+                grabSelection(false);
+                if (carrying()) postStatus("Copied " + std::to_string(carriedCount()) + " - originals left in place.", 180);
+                return;
+            }
+            if (!holding) {
+                sortStorageBox(storageFocusPane, storageFocusPane == 0 ? stSaveBox : stBankBox);
+                return;
+            }
         }
 
-        // A: act. Holding overrides the mode (place/swap the carried Pokemon; menu suppressed).
+        // A: act. A full hand overrides the mode -- it always means "put the block down here".
         if (kDown & HidNpadButton_A) {
             // Box-name header focused: A renames this pane's box (save box, or bank box). Guard first
             // so the placement/menu code below never indexes storage with slot == -1.
@@ -1352,26 +1501,17 @@ namespace UI {
                 return;
             }
             if (holding) {
-                // Confirm first for a lossy conversion: a Gen 3 downgrade rebuilds the PID (always warned),
-                // or -- settings-gated -- a Let's Go cross-move that resets AVs/EVs.
-                const bool g3warn = !isLocked(pane, box, slot) && gen3DowngradeInvolved(pane, heldPokemon.get());
-                const bool lgwarn = g_lgpeMoveWarn && !isLocked(pane, box, slot) && lgpeConversionInvolved(pane, heldPokemon.get());
+                // Confirm first for a lossy conversion: a Gen 3 downgrade rebuilds the PID (always
+                // warned), or -- settings-gated -- a Let's Go cross-move that resets AVs/EVs.
+                const bool g3warn = blockInvolvesGen3Downgrade(pane);
+                const bool lgwarn = g_lgpeMoveWarn && blockInvolvesLgpe(pane);
                 if (g3warn || lgwarn) {
                     lgpePending = LgpePending::PlaceHeld;
                     lgpePendPane = pane; lgpePendBox = box; lgpePendSlot = slot;
                     moveConfirmGen3 = g3warn; lgpeMoveConfirmActive = true; lgpeMoveConfirmIndex = 1;
                     return;
                 }
-                if (!isLocked(pane, box, slot) && prepareHeldForPane(pane)) {
-                    auto& here = slotPtr(pane, box, slot);
-                    if (!occupied(pane, box, slot)) {
-                        here = std::move(heldPokemon);
-                    } else {
-                        std::swap(here, heldPokemon);
-                        heldPane = pane; heldFromBox = box; heldFromSlot = slot;
-                    }
-                    hasUnsavedChanges = true;
-                }
+                putDownBlock();
                 return;
             }
             switch (cursorMode) {
@@ -1384,7 +1524,7 @@ namespace UI {
                         storageMenuActive = true;
                         storageMenuIndex = isLocked(pane, box, slot) ? 1 : 0;
                         menuPane = pane; menuBox = box; menuSlot = slot;
-                    } else if (pane == 0 && !occupied(pane, box, slot) && !isLocked(pane, box, slot)) {
+                    } else if (pane == 0 && !isLocked(pane, box, slot)) {
                         // Empty save-pane slot: create a new Pokemon here (pick species, then edit).
                         creator.active = true; creator.pane = pane; creator.box = box; creator.slot = slot;
                         pickerKind = Dialogs::PickerKind::Species;
@@ -1394,33 +1534,8 @@ namespace UI {
                     }
                     break;
                 case CursorMode::Move:
-                    if (occupied(pane, box, slot) && !isLocked(pane, box, slot)) {
-                        heldPokemon = std::move(slotPtr(pane, box, slot));
-                        heldPane = pane; heldFromBox = box; heldFromSlot = slot;
-                    }
-                    break;
                 case CursorMode::Multi:
-                    if (occupied(pane, box, slot) && !isLocked(pane, box, slot)) {
-                        // Occupied slot: toggle it in the selection (single-pane; crossing resets it).
-                        if (!multiSel.empty() && multiSel.front().pane != pane) multiSel.clear();
-                        bool found = false;
-                        for (size_t i = 0; i < multiSel.size(); ++i)
-                            if (multiSel[i].pane == pane && multiSel[i].box == box && multiSel[i].slot == slot) {
-                                multiSel.erase(multiSel.begin() + i); found = true; break;
-                            }
-                        if (!found) multiSel.push_back({pane, box, slot});
-                    } else if (!occupied(pane, box, slot) && !isLocked(pane, box, slot) && !multiSel.empty()) {
-                        // Empty slot with a selection: move the whole group here (cross-pane = deposit/withdraw).
-                        const bool g3warn = selectionInvolvesGen3Downgrade(pane);
-                        const bool lgwarn = g_lgpeMoveWarn && selectionInvolvesLgpe(pane);
-                        if (g3warn || lgwarn) {   // confirm a lossy conversion (Gen 3 PID rebuild / LGPE AV-EV reset)
-                            lgpePending = LgpePending::GroupMoveTo;
-                            lgpePendPane = pane; lgpePendBox = box; lgpePendSlot = slot;
-                            moveConfirmGen3 = g3warn; lgpeMoveConfirmActive = true; lgpeMoveConfirmIndex = 1;
-                        } else {
-                            moveSelectionTo(pane, box, slot);
-                        }
-                    }
+                    storagePickup();
                     break;
             }
         }
@@ -1435,9 +1550,15 @@ namespace UI {
         // path returns before ever reaching the bottom -- so an end-of-update hook would silently
         // skip them, and per-site hooks are exactly the coverage gap this codebase keeps hitting.
         // A no-op on every positional game. Excluded mid-operation so the board can't shift under a
-        // Pokemon the user is currently carrying, swapping or creating.
-        if (!heldPokemon && !swapActive && !creator.active && trainer.compactStorage()) {
-            multiSel.clear();   // entries are (pane, box, slot) refs; a re-pack invalidates them
+        // Pokemon the user is currently carrying, swapping, selecting or creating.
+        //
+        // This IS the "exception for LGPE" in exact-slot placement: a block still lands on the exact
+        // slots it was dropped onto, and then this closes any gap those slots left behind, sliding
+        // the box forward. Nothing here can invalidate a selection any more -- a carried block owns
+        // its Pokemon outright rather than pointing at slots -- but an in-progress rectangle is
+        // anchored to slot indices, so it is excluded too.
+        if (!carrying() && !currentlySelecting && !swapActive && !creator.active) {
+            trainer.compactStorage();
         }
 
         // Keep the game's persisted "current box" in step with whichever box view is open, so it
@@ -2451,8 +2572,10 @@ namespace UI {
             else if (tb == 0) kDown |= HidNpadButton_B;  // tap Cancel
             if (kDown & HidNpadButton_A) {
                 if (releaseGroup) {
-                    for (const auto& s : multiSel) storageSlot(s.pane, s.box, s.slot).reset();
-                    multiSel.clear();
+                    // The group being released is the block in hand, so releasing it is simply
+                    // dropping what we are carrying -- nothing is left pointing at a stale slot.
+                    moveMon.clear();
+                    selectDimensions = {0, 0};
                 } else {
                     storageSlot(releasePane, releaseBox, releaseSlot).reset();
                 }
@@ -2500,20 +2623,14 @@ namespace UI {
             if (kDown & HidNpadButton_B) { lgpeMoveConfirmActive = false; lgpePending = LgpePending::None; return; }
             if (kDown & HidNpadButton_A) {   // Continue: run the stashed action (A always continues)
                 lgpeMoveConfirmActive = false;
-                switch (lgpePending) {
-                    case LgpePending::PlaceHeld: {
-                        const int p = lgpePendPane, b = lgpePendBox, s = lgpePendSlot;
-                        if (!storageSlotLocked(p, b, s) && prepareHeldForPane(p)) {
-                            auto& here = storageSlot(p, b, s);
-                            if (!here || here->speciesID() == 0) here = std::move(heldPokemon);
-                            else { std::swap(here, heldPokemon); heldPane = p; heldFromBox = b; heldFromSlot = s; }
-                            hasUnsavedChanges = true;
-                        }
-                        break;
-                    }
-                    case LgpePending::GroupMoveTo:   moveSelectionTo(lgpePendPane, lgpePendBox, lgpePendSlot); break;
-                    case LgpePending::GroupTransfer: transferSelectionToOtherPane(); break;
-                    default: break;
+                if (lgpePending == LgpePending::PlaceHeld) {
+                    // Re-point the cursor at the slot the drop was aimed at, then run the ordinary
+                    // put-down -- one placement path, so the confirmed move behaves identically to
+                    // the unconfirmed one (bounds, block swap, per-cell conversion and all).
+                    storageFocusPane = lgpePendPane;
+                    if (lgpePendPane == 0) { stSaveBox = lgpePendBox; stSaveSlot = lgpePendSlot; }
+                    else                   { stBankBox = lgpePendBox; stBankSlot = lgpePendSlot; }
+                    putDownBlock();
                 }
                 lgpePending = LgpePending::None;
                 return;
@@ -2536,10 +2653,13 @@ namespace UI {
             if (kDown & HidNpadButton_A) {
                 storageMenuActive = false;
                 switch (storageMenuIndex) {
-                    case 0:  // Move -> pick up (blocked on a party-linked slot)
+                    case 0:  // Move -> pick up as a 1x1 block (blocked on a party-linked slot)
                         if (menuLocked) break;
-                        heldPokemon = std::move(storageSlot(menuPane, menuBox, menuSlot));
-                        heldPane = menuPane; heldFromBox = menuBox; heldFromSlot = menuSlot;
+                        storageFocusPane = menuPane;
+                        if (menuPane == 0) { stSaveBox = menuBox; stSaveSlot = menuSlot; }
+                        else               { stBankBox = menuBox; stBankSlot = menuSlot; }
+                        pickupSingle();
+                        postPickup();
                         break;
                     case 1:  // Edit -> open the details modal
                         openStorageEditor(menuPane, menuBox, menuSlot);
@@ -2584,9 +2704,10 @@ namespace UI {
             return;
         }
 
-        // Handle the green-mode group menu (Move / Release / Clear / Cancel).
+        // Handle the carried-block menu, opened with Minus (Release all / Return / Cancel). Moving a
+        // block no longer needs a menu entry -- you carry it to where you want it and press A.
         if (groupMenuActive) {
-            constexpr int N = 4;
+            constexpr int N = 3;
             int tb = touchedButtonId(touch);
             if (tb >= 0) { groupMenuIndex = tb; kDown |= HidNpadButton_A; }  // tap a row = select + confirm
             if (kDown & HidNpadButton_Up)   groupMenuIndex = (groupMenuIndex - 1 + N) % N;
@@ -2595,20 +2716,8 @@ namespace UI {
             if (kDown & HidNpadButton_A) {
                 groupMenuActive = false;
                 switch (groupMenuIndex) {
-                    case 0: {  // Move to the other pane
-                        const int destPane = multiSel.empty() ? 1 : (1 - multiSel.front().pane);
-                        const bool g3warn = selectionInvolvesGen3Downgrade(destPane);
-                        const bool lgwarn = g_lgpeMoveWarn && selectionInvolvesLgpe(destPane);
-                        if (g3warn || lgwarn) {   // confirm a lossy conversion (Gen 3 PID rebuild / LGPE AV-EV reset)
-                            lgpePending = LgpePending::GroupTransfer;
-                            moveConfirmGen3 = g3warn; lgpeMoveConfirmActive = true; lgpeMoveConfirmIndex = 1;
-                        } else {
-                            transferSelectionToOtherPane();
-                        }
-                        break;
-                    }
-                    case 1: releaseGroup = true; releaseConfirmActive = true; break;  // Release all
-                    case 2: multiSel.clear(); break;  // Clear selection
+                    case 0: releaseGroup = true; releaseConfirmActive = true; break;  // Release all
+                    case 1: returnHeldToOrigin(); break;                              // Put it all back
                     default: break;  // Cancel
                 }
                 return;
@@ -2658,7 +2767,7 @@ namespace UI {
                     case 1:  // Discard & Exit -> revert the in-memory bank to its on-disk state.
                              // ONLY the bank: it owns what lives in the bank, not what lives in the
                              // save. Pulling a Pokemon out and then discarding therefore leaves the
-                             // copy in the save box -- intended, and what PKSM does. Undoing that half
+                             // copy in the save box -- intended, and how a HOME-style box works. Undoing that half
                              // is the GAME save's own discard, which is a separate decision.
                         if (bank) bank->load();
                         detailViewActive = false;
@@ -2678,11 +2787,12 @@ namespace UI {
         if (detailViewActive) {
             if (kDown & HidNpadButton_B) {
                 if (selectedMode == ViewMode::Storage) {
-                    // B unwinds one step: drop a carried Pokemon, then clear a multi-selection, then exit.
-                    if (heldPokemon) { returnHeldToOrigin(); return; }
-                    if (!multiSel.empty()) { multiSel.clear(); return; }
+                    // B unwinds one step: abandon a rectangle being drawn, then put a carried block
+                    // back where it came from, then leave the view.
+                    if (currentlySelecting) { cancelSelection(); return; }
+                    if (carrying()) { returnHeldToOrigin(); return; }
                     // Leaving the storage view: if the bank has unsaved changes, prompt Save / Discard /
-                    // Cancel (PKSM does the same on its storage back button). No changes -> just exit.
+                    // Cancel. No changes -> just exit.
                     // The bank is its own entity, saved here rather than with the game (X) save.
                     if (bank && bank->hasChanged()) {
                         storageExitConfirmActive = true;
@@ -2705,9 +2815,36 @@ namespace UI {
 
             // Storage view: dual-pane bank navigation + deposit/withdraw.
             if (selectedMode == ViewMode::Storage) {
-                // Touch: a tap on a slot moves the cursor there and acts like pressing A, so it
-                // works in every cursor mode (Menu opens the popup, Move picks up/places, Multi
-                // toggles/moves). Rects were captured during the previous frame's draw.
+                // Touch drag-select (Multi mode): press anchors the rectangle, sliding a finger over
+                // the grid rubber-bands it, lifting grabs the block. The same gesture the D-pad does
+                // with A / move / A -- so a rectangle can be swept out in one motion.
+                //
+                // Only the anchor's own pane and box take part: a rectangle is a region of ONE box,
+                // and the cursor slot is what the highlight and the grab both read.
+                auto slotUnderFinger = [&](int& outPane, int& outSlot) {
+                    for (const auto& t : storageTouchTargets) {
+                        if (t.slot < 0) continue;                      // header arrows / name pill
+                        if (touch.x() >= t.x && touch.x() < t.x + t.w &&
+                            touch.y() >= t.y && touch.y() < t.y + t.h) {
+                            outPane = t.pane; outSlot = t.slot; return true;
+                        }
+                    }
+                    return false;
+                };
+                if (currentlySelecting && touch.isDown() && !touch.justPressed()) {
+                    int tp = 0, ts = 0;
+                    if (slotUnderFinger(tp, ts) && tp == selectPane) {
+                        if (tp == 0) stSaveSlot = ts; else stBankSlot = ts;
+                    }
+                }
+                if (currentlySelecting && touch.justReleased() && touch.dragged()) {
+                    grabSelection(true);     // a swept-out rectangle grabs on lift
+                    return;
+                }
+
+                // A tap on a slot moves the cursor there and acts like pressing A, so it works in
+                // every cursor mode (Menu opens the popup, Move picks up/places, Multi anchors then
+                // grabs). Rects were captured during the previous frame's draw.
                 if (touch.justPressed()) {
                     for (const auto& t : storageTouchTargets) {
                         if (touch.x() >= t.x && touch.x() < t.x + t.w &&
@@ -3277,7 +3414,8 @@ namespace UI {
                     break;
                 case 2:  // Storage (bank) — start on the save pane, Menu mode, nothing held/selected.
                     detailViewActive = true; storageFocusPane = 0; stSaveSlot = 0; stBankSlot = 0;
-                    multiSel.clear(); storageMenuActive = false; groupMenuActive = false;
+                    moveMon.clear(); selectDimensions = {0, 0}; currentlySelecting = false;
+                    storageMenuActive = false; groupMenuActive = false;
                     cursorMode = CursorMode::Menu;
                     break;
                 case 3:  // Items
@@ -3542,14 +3680,18 @@ namespace UI {
                     instructions = "Up/Down: Choose  |  A: Select  |  B: Cancel";
                 } else if (releaseConfirmActive) {
                     instructions = "A: Release  |  B: Cancel";
-                } else if (heldPokemon) {
-                    instructions = "Arrows: Move (cross panes at edge)  |  L/R: Box  |  A: Drop / Swap  |  B: Return";
+                } else if (currentlySelecting) {
+                    instructions = "Arrows: Size Selection  |  A: Grab Group  |  X: Copy Group  |  B: Cancel";
+                } else if (carrying()) {
+                    instructions = carriedCount() > 1
+                        ? "Arrows: Move Group (cross panes at edge)  |  L/R: Box  |  A: Place Here  |  Minus: Options  |  B: Put Back"
+                        : "Arrows: Move (cross panes at edge)  |  L/R: Box  |  A: Drop / Swap  |  Minus: Options  |  B: Put Back";
                 } else if (cursorMode == CursorMode::Menu) {
                     instructions = "Arrows: Move  |  L/R: Box  |  Y: Mode (Menu)  |  A: Menu  |  X: Sort Box  |  B: Back";
                 } else if (cursorMode == CursorMode::Move) {
                     instructions = "Arrows: Move  |  L/R: Box  |  Y: Mode (Move)  |  A: Pick Up  |  X: Sort Box  |  B: Back";
                 } else {
-                    instructions = "Arrows: Move  |  A: Select  |  Minus: Options  |  Y: Mode (Multi)  |  X: Sort Box  |  B: Clear";
+                    instructions = "Arrows: Move  |  L/R: Box  |  Y: Mode (Multi)  |  A: Start Selection  |  X: Sort Box  |  B: Back";
                 }
             } else if (selectedMode == ViewMode::Trainer) {
                 // X saves only from the HOME menu (see the X handler), so the flow is edit -> B -> X.


### PR DESCRIPTION
…the box grid

Replaces the bank's toggle-per-slot multi-selection with a HOME-style model: A anchors a corner, moving the cursor rubber-bands a rectangle, A again lifts every slot inside it, and the block then rides the cursor across boxes and panes until A drops it.

Placement is positional — cell (x, y) lands in slot cursor + x + y*cols and swaps with whatever was there -- rather than "fill the next free slot", so the arrangement you pick up is the arrangement you put down, and the move is reversible. A drop that would hang off the grid is refused and tinted rather than silently repacked.

Let's Go is the documented exception: the block still lands on the exact slots it was dropped onto, and compactStorage() closes the gaps on the next frame, because its storage is one gapless list that cannot represent a hole.

Carry state is unified. heldPokemon (single) and multiSel (slot refs) are gone; a Move-mode pick-up is now a 1x1 block in moveMon, so every guard that asks "are we holding something?" — compaction, sort, exit, box rename, B-unwind — answers for both cases at once instead of two states needing to stay in sync. It also removes a class of bug by construction: a carried block owns its Pokemon outright, so a re-pack can no longer invalidate a selection.

The circle highlight is replaced by a drawn arrowhead resting above the slot, coloured by cursor mode (red Menu / blue Move / green Multi, theme-aware) and sized absolutely at 32px — the two grids size their discs differently, so scaling off the disc gave a visibly bigger cursor in one view than the other.

The Boxes view gets the same cursor in its own indigo/amber palette and the same "picked up" visual — a grabbed slot draws empty while its Pokemon rides the cursor. That view is unchanged underneath: it still swaps on the second Y rather than lifting into moveMon, because swapBoxSlots carries the Let's Go party-pointer remapping and rewriting it for a purely visual gain is not worth the risk. Shared drawLiftedMon keeps the two looking identical.

Also:
- Fix a fall-through where convertForPane failing after canConvert passed wrote an unconverted foreign Pokemon into the save — a Bad Egg in game. It now stays in hand and the blocker is named.
- Touch drag-select: press, slide, lift sweeps out a rectangle in one gesture.
- Drop the Boxes view's selection scale-pop, which the bank never had.
- Remove drawNameCursorLabel; the box grid was its only caller.
- Refer to Pokemon HOME rather than PKSM throughout the comments; the storage model descends from Pokemon Bank and HOME. Citations where a specific implementation was actually the reference are reworded rather than reattributed.

Bank multi-select and the cursor were validated on hardware. The box-side cursor and carry visual, and the final 32px sizing, are build-verified only.

Closes #55