### PR TITLE
fix: only require a backup's main save file when writing to the game

### DIFF
--- a/CppProperties.json
+++ b/CppProperties.json
@@ -22,7 +22,7 @@
         "__SWITCH__",
         "_REENTRANT",
         "NVG_NO_STB",
-        "PKSE_VERSION=\"1.1.2-pre-release-debug\""
+        "PKSE_VERSION=\"1.1.2\""
       ]
     }
   ]

--- a/CppProperties.json
+++ b/CppProperties.json
@@ -1,0 +1,29 @@
+{
+  "configurations": [
+    {
+      "name": "Switch (devkitA64)",
+      "intelliSenseMode": "linux-gcc-arm64",
+      "compilerSwitches": "-std=c++20 -fno-rtti -fno-exceptions -march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE -ftls-model=local-exec",
+      "includePath": [
+        "${workspaceRoot}/include",
+        "${workspaceRoot}/nanovg",
+        "${workspaceRoot}/build",
+        "C:/devkitPro/devkitA64/aarch64-none-elf/include/c++/16.1.0",
+        "C:/devkitPro/devkitA64/aarch64-none-elf/include/c++/16.1.0/aarch64-none-elf",
+        "C:/devkitPro/devkitA64/aarch64-none-elf/include/c++/16.1.0/backward",
+        "C:/devkitPro/devkitA64/lib/gcc/aarch64-none-elf/16.1.0/include",
+        "C:/devkitPro/devkitA64/lib/gcc/aarch64-none-elf/16.1.0/include-fixed",
+        "C:/devkitPro/devkitA64/aarch64-none-elf/include",
+        "C:/devkitPro/libnx/include",
+        "C:/devkitPro/portlibs/switch/include",
+        "C:/devkitPro/portlibs/switch/include/SDL2"
+      ],
+      "defines": [
+        "__SWITCH__",
+        "_REENTRANT",
+        "NVG_NO_STB",
+        "PKSE_VERSION=\"1.1.2-pre-release-debug\""
+      ]
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,30 @@ DATA		:=	data
 INCLUDES	:=	include nanovg
 APP_TITLE   :=  PKSE
 APP_AUTHOR  :=  Kiasta
-# THE version. Globals.h derives VERSION_STRING from this via -DPKSE_VERSION below, so this is the
-# single source of truth -- the two can no longer drift.
-# NOTE: no trailing comment on the assignment line. Make keeps trailing whitespace in a value, so
+# THE version, in two spellings. Both are set here and nothing downstream needs editing.
+#
+# APP_VERSION is the .nacp one -- the home menu and hbmenu read it. The name is not ours to choose:
+# libnx's switch_rules passes $(APP_VERSION) straight to `nacptool --create`. Its display_version
+# field is 16 bytes and nacptool truncates to fit WITHOUT complaining (exit 0, no warning), so this
+# must stay at 15 characters or fewer -- "1.1.2-pre-release-debug" was silently becoming
+# "1.1.2-pre-relea" in the .nro.
+#
+# APP_VERSION_FULL is the one the app prints about itself: -DPKSE_VERSION below feeds it to
+# Globals.h's VERSION_STRING, which has no length limit. Long pre-release tags belong here.
+#
+# Keep the short one an ABBREVIATION of the long one. The split exists so the .nacp can hold less of
+# the version, not a different version.
+#
+# NOTE: no trailing comment on either assignment line. Make keeps trailing whitespace in a value, so
 # "0.0.3 \t\t# ..." would have baked spaces into the .nacp version and the -D define.
-APP_VERSION :=	1.1.1
+APP_VERSION :=	1.1.2-pre-debug
+APP_VERSION_FULL :=	1.1.2-pre-release-debug
+
+# Mirrors what switch_rules does for APP_VERSION: an unset long form falls back to the short one
+# rather than compiling in an empty version string.
+ifeq ($(strip $(APP_VERSION_FULL)),)
+APP_VERSION_FULL := $(APP_VERSION)
+endif
 ROMFS		:=	romfs
 ICON		:=  assets/icon.jpg
 
@@ -59,7 +78,7 @@ ARCH	:=	-march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
 
 # NanoVG: disable its stb_image (we feed RGBA buffers via nvgCreateImageRGBA, and SpriteManager
 # already owns the STB_IMAGE_IMPLEMENTATION) — avoids duplicate symbols. Keeps fontstash for text.
-DEFINES	:=	-DNVG_NO_STB -DPKSE_VERSION='"$(APP_VERSION)"'
+DEFINES	:=	-DNVG_NO_STB -DPKSE_VERSION='"$(APP_VERSION_FULL)"'
 
 #---------------------------------------------------------------------------------
 # Production builds:  make clean && make all prod

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ APP_AUTHOR  :=  Kiasta
 #
 # NOTE: no trailing comment on either assignment line. Make keeps trailing whitespace in a value, so
 # "0.0.3 \t\t# ..." would have baked spaces into the .nacp version and the -D define.
-APP_VERSION :=	1.1.2-pre-debug
-APP_VERSION_FULL :=	1.1.2-pre-release-debug
+APP_VERSION :=	1.1.2
+APP_VERSION_FULL :=	1.1.2
 
 # Mirrors what switch_rules does for APP_VERSION: an unset long form falls back to the short one
 # rather than compiling in an empty version string.

--- a/include/Globals.h
+++ b/include/Globals.h
@@ -3,16 +3,24 @@
 
 #include <string>
 
-/// Derived from the Makefile's APP_VERSION via -DPKSE_VERSION, so the on-screen version and the
-/// .nacp version cannot drift apart -- they are now the same string, set in one place.
+/// Derived from the Makefile's APP_VERSION_FULL via -DPKSE_VERSION. That is the long spelling; the
+/// .nacp separately carries APP_VERSION, an abbreviation of it, because its display_version field
+/// holds only 15 characters. Both are set side by side in the Makefile, so the two can differ in
+/// how much of the version they show but not in which version it is.
 ///
 /// The fallback is deliberately loud rather than a plausible-looking number. This header is also
 /// parsed by the Visual Studio projects (IntelliSense only, never the real build), which don't pass
 /// the define; a fallback like "0.0.3" would silently look correct while being a guess.
+///
+/// Deliberately `const` and not `constexpr`. A constant-evaluated std::string has to fit inside
+/// libstdc++'s small-string buffer -- 15 characters -- because anything longer heap-allocates, and
+/// an allocation cannot escape constant evaluation into the runtime. Any pre-release tag blows past
+/// that, and the fallback below is already sitting exactly on 15, so `constexpr` here was one
+/// character away from breaking on its own. Nothing evaluates this at compile time anyway.
 #ifndef PKSE_VERSION
 #define PKSE_VERSION "0.0.0-NOVERSION"
 #endif
-inline constexpr std::string VERSION_STRING = PKSE_VERSION;
+inline const std::string VERSION_STRING = PKSE_VERSION;
 
 inline constexpr std::string BASE_SAVE_DIRECTORY = "sdmc:/PKSE";
 

--- a/include/Utils/FileUtilities.h
+++ b/include/Utils/FileUtilities.h
@@ -21,7 +21,12 @@ namespace Utils {
     std::string backupSaveData(AccountUid userUid, u64 titleId, std::string titleName, bool timestamped = true);
     // Copy a backup's save files onto the real game save. The backup directory IS the edited
     // save -- PKSE writes edits straight into it -- so there is no separate "modified" copy.
-    bool restoreBackupToTitle(AccountUid userUid, u64 titleId, const char* backupDir, std::vector<std::string> saveFiles);
+    // `primaryFile` is the one file a backup must hold; the game's `optionalFiles` beside it are
+    // copied when present and passed over in silence when not, because whether they exist at all
+    // depends on what the player has done in-game.
+    bool restoreBackupToTitle(AccountUid userUid, u64 titleId, const char* backupDir,
+                              const std::string& primaryFile,
+                              const std::vector<std::string>& optionalFiles = {});
     std::string getTimestamp();
     std::vector<std::string> listBackupDirectories(const char* gameDirectory);
 }

--- a/src/Save/GetSaveFileContents.cpp
+++ b/src/Save/GetSaveFileContents.cpp
@@ -265,8 +265,7 @@ namespace Save {
 
         if (injectToTitle) {
             logInfoToFile("Restoring modified Let's Go save to game save device...");
-            std::vector<std::string> saveFiles = {"savedata.bin"};
-            if (!restoreBackupToTitle(userUid, titleId, backupDir, saveFiles)) {
+            if (!restoreBackupToTitle(userUid, titleId, backupDir, "savedata.bin")) {
                 logErrorToFile("Failed to restore modified Let's Go save to game");
                 return false;
             }
@@ -342,8 +341,7 @@ namespace Save {
         // Only write into the real game save when THIS save was told to inject
         if (injectToTitle) {
             logInfoToFile("Restoring modified save to game save device...");
-            std::vector<std::string> saveFiles = {"main", "backup", "poke_trade"};
-            if (!restoreBackupToTitle(userUid, titleId, backupDir, saveFiles)) {
+            if (!restoreBackupToTitle(userUid, titleId, backupDir, "main", {"backup", "poke_trade"})) {
                 logErrorToFile("Failed to restore modified save to game");
                 return false;
             }
@@ -465,8 +463,7 @@ namespace Save {
 
         if (injectToTitle) {
             logInfoToFile("Restoring modified BDSP save to game save device...");
-            std::vector<std::string> saveFiles = { "SaveData.bin", "Backup.bin" };
-            if (!restoreBackupToTitle(userUid, titleId, backupDir, saveFiles)) {
+            if (!restoreBackupToTitle(userUid, titleId, backupDir, "SaveData.bin", {"Backup.bin"})) {
                 logErrorToFile("Failed to restore modified save to game");
                 return false;
             }
@@ -510,8 +507,11 @@ namespace Save {
 
         if (injectToTitle) {
             logInfoToFile("Restoring modified save to game save device...");
-            std::vector<std::string> saveFiles = {"main"};
-            if (!restoreBackupToTitle(userUid, titleId, backupDir, saveFiles)) {
+            // Legends: Arceus pairs main with main2 -- NOT with Sword/Shield's backup/poke_trade.
+            // It has no Surprise Trade, so there is no pending trade result for a poke_trade to
+            // hold. Confirmed against real backups; `backup` is carried too because it has been
+            // reported beside them, and a save without one just skips it.
+            if (!restoreBackupToTitle(userUid, titleId, backupDir, "main", {"main2", "backup"})) {
                 logErrorToFile("Failed to restore modified save to game");
                 return false;
             }
@@ -560,8 +560,10 @@ namespace Save {
         // Only write into the real game save when THIS save was told to inject
         if (injectToTitle) {
             logInfoToFile("Restoring modified save to game save device...");
-            std::vector<std::string> saveFiles = {"main"};
-            if (!restoreBackupToTitle(userUid, titleId, backupDir, saveFiles)) {
+            // Only `main` has ever turned up in a real Z-A backup. backup/poke_trade are listed
+            // regardless because Z-A shares Scarlet/Violet's save format, where both exist and are
+            // written conditionally -- if Z-A never produces them they are skipped and cost nothing.
+            if (!restoreBackupToTitle(userUid, titleId, backupDir, "main", {"backup", "poke_trade"})) {
                 logErrorToFile("Failed to restore modified save to game");
                 return false;
             }
@@ -605,8 +607,7 @@ namespace Save {
 
         if (injectToTitle) {
             logInfoToFile("Restoring modified save to game save device...");
-            std::vector<std::string> saveFiles = {"main"};
-            if (!restoreBackupToTitle(userUid, titleId, backupDir, saveFiles)) {
+            if (!restoreBackupToTitle(userUid, titleId, backupDir, "main", {"backup", "poke_trade"})) {
                 logErrorToFile("Failed to restore modified save to game");
                 return false;
             }
@@ -702,8 +703,7 @@ namespace Save {
 
         if (injectToTitle) {
             logInfoToFile("Restoring modified FRLG save to game save device...");
-            std::vector<std::string> saveFiles = { name };
-            if (!restoreBackupToTitle(userUid, titleId, backupDir, saveFiles)) {
+            if (!restoreBackupToTitle(userUid, titleId, backupDir, name)) {
                 logErrorToFile("Failed to restore modified FRLG save to game");
                 return false;
             }

--- a/src/Utils/FileUtilities.cpp
+++ b/src/Utils/FileUtilities.cpp
@@ -10,6 +10,7 @@
 
 #include <switch.h>
 #include <sys/dirent.h>
+#include <sys/stat.h>
 #include <sys/unistd.h>
 
 #include "Globals.h"
@@ -262,6 +263,13 @@ namespace Utils {
         return "";
     }
 
+    // Tells "the backup never held this file" apart from "the copy failed". Both reach copyFile as
+    // the same failed fopen, but only the second one is an error worth reporting.
+    static bool backupHasFile(const char* path) {
+        struct stat st{};
+        return stat(path, &st) == 0 && S_ISREG(st.st_mode);
+    }
+
     /**
      * Copy a backup's save files onto the real game save.
      *
@@ -270,10 +278,38 @@ namespace Utils {
      * subdirectory and only the inject path ever read them back out -- which meant saving to a
      * backup silently changed nothing the loader would ever see. That directory is gone, so the
      * two paths collapsed into one and the second copy pass with them.
+     *
+     * Only `primaryFile` has to exist. Which companion files sit beside it is a property of the
+     * individual save, not of the game: Sword/Shield's `poke_trade` holds a Surprise Trade result
+     * that has not been collected yet, so a save that never sent one simply has no such file. The
+     * list used to be a flat per-game array of required names, which made that ordinary case fatal
+     * -- the copy loop broke on the missing file and returned before `fsdevCommitDevice`, so the
+     * writes already made to save:/ were dropped on unmount and the user's edit disappeared with a
+     * "failed to copy" error naming a file they were never supposed to have.
+     *
+     * So an absent optional file is skipped and not logged as a failure. A file that IS there and
+     * will not copy still stops the restore, before the commit, leaving the game save untouched.
      */
-    bool restoreBackupToTitle(AccountUid userUid, u64 titleId, const char* backupDir, std::vector<std::string> saveFiles) {
+    bool restoreBackupToTitle(AccountUid userUid, u64 titleId, const char* backupDir,
+                              const std::string& primaryFile,
+                              const std::vector<std::string>& optionalFiles) {
         char buffer[LOG_BUFFER_SIZE];
         logInfoToFile("Restoring backup to game save", backupDir);
+
+        if (primaryFile.empty()) {
+            logErrorToFile("No primary save file specified for restore");
+            return false;
+        }
+
+        // Checked before mounting: if the one required file is missing there is nothing this can
+        // do, and bailing here means never having opened the game's save data at all.
+        char primaryPath[512];
+        snprintf(primaryPath, sizeof(primaryPath), "%s/%s", backupDir, primaryFile.c_str());
+        if (!backupHasFile(primaryPath)) {
+            snprintf(buffer, sizeof(buffer), "Backup has no %s to restore", primaryFile.c_str());
+            logErrorToFile(buffer);
+            return false;
+        }
 
         Result result = fsdevMountSaveData("save", titleId, userUid);
 
@@ -285,23 +321,35 @@ namespace Utils {
 
         logInfoToFile("Successfully mounted save:/ for restore");
 
-        // Copy the named save files only, never subdirectories. The list is per-game:
-        // Sword/Shield has main, backup and poke_trade; most others are a single file.
+        // Copy the named save files only, never subdirectories.
         logInfoToFile("Copying backup save files to save:/", backupDir);
 
+        char srcPath[512];
+        char destPath[512];
         bool copyAllSuccess = true;
 
-        for (size_t i = 0; i < saveFiles.size(); i++) {
-            char srcPath[512];
-            char destPath[512];
-            snprintf(srcPath, sizeof(srcPath), "%s/%s", backupDir, saveFiles[i].c_str());
-            snprintf(destPath, sizeof(destPath), "save:/%s", saveFiles[i].c_str());
+        snprintf(destPath, sizeof(destPath), "save:/%s", primaryFile.c_str());
+        if (!copyFile(primaryPath, destPath)) {
+            snprintf(buffer, sizeof(buffer), "Failed to copy %s", primaryFile.c_str());
+            logErrorToFile(buffer);
+            copyAllSuccess = false;
+        }
 
+        for (size_t i = 0; copyAllSuccess && i < optionalFiles.size(); i++) {
+            snprintf(srcPath, sizeof(srcPath), "%s/%s", backupDir, optionalFiles[i].c_str());
+
+            if (!backupHasFile(srcPath)) {
+                // Ordinary: this save never produced the file. Whatever the game currently has
+                // under that name stays where it is.
+                logInfoToFile("Not in this backup, leaving the game's copy alone", optionalFiles[i].c_str());
+                continue;
+            }
+
+            snprintf(destPath, sizeof(destPath), "save:/%s", optionalFiles[i].c_str());
             if (!copyFile(srcPath, destPath)) {
-                snprintf(buffer, sizeof(buffer), "Failed to copy %s", saveFiles[i].c_str());
+                snprintf(buffer, sizeof(buffer), "Failed to copy %s", optionalFiles[i].c_str());
                 logErrorToFile(buffer);
                 copyAllSuccess = false;
-                break;
             }
         }
 
@@ -311,13 +359,8 @@ namespace Utils {
             return false;
         }
 
-        // No second pass. The loop above already copied the edited primary file, because the
+        // No second pass. The copies above already wrote the edited primary file, because the
         // backup directory holds the edits -- there is no separate "modified" copy to overlay.
-        if (saveFiles.empty()) {
-            logErrorToFile("No save files specified for restore");
-            fsdevUnmountDevice("save");
-            return false;
-        }
 
         // CRITICAL: Commit changes to the save device before unmounting
         // Without this, changes remain in memory buffers and are never written to disk


### PR DESCRIPTION
Writing an edited save into the game failed outright for any Sword/Shield save whose backup had no poke_trade, logging "Failed to copy poke_trade"
after main and backup had already gone across.

poke_trade is not a fixture of a Sword/Shield save. It holds a Surprise Trade result that has not been collected yet, so a save that has never
sent one simply does not have the file, and its backup faithfully does not either. The restore list treated all three names as required, which
made that ordinary case read as a failure.

The edit was then lost rather than half-applied: the copy loop broke on the missing file and returned before fsdevCommitDevice, so the writes
already made to save:/ were discarded on unmount. Nothing was corrupted by this and the game save was left exactly as it was, but the user's work
was gone and the error named a file they were never supposed to have.

restoreBackupToTitle now takes the one required file separately from the companion files beside it. A companion missing from the backup is skipped
and not reported as a failure, leaving whatever the game already had under that name in place. A companion that is present and will not copy
still stops the restore, before the commit, so a real I/O fault is still caught. The required file is checked before mounting, so a restore that
cannot possibly work never opens the game's save data at all.

All seven games now only require their main saves and optionally the others — like poke_trade. Scarlet/Violet, Legends: Arceus and Legends: Z-A previously restored only main and now push backup and
poke_trade alongside it when the backup holds them, which is safe to list now that an absent file is skipped rather than fatal.

Reported against 1.1.0; also present in 1.1.1.

Closes #97 